### PR TITLE
fix(ci): use commit SHA instead of tag object SHA for pypi-publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Publish PyPI
         if: inputs.publish-enabled && (steps.release.outputs.released || steps.release-current.outputs.released)
         # from tag: v1.14.0
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           print-hash: true
           verify-metadata: true


### PR DESCRIPTION
The previous pin used the annotated tag object hash, not the underlying commit, causing Docker to fail with "manifest unknown".