### PR TITLE
fix(ci): disable attestations for pypi-publish v1.14.0

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -200,4 +200,5 @@ jobs:
         with:
           print-hash: true
           verify-metadata: true
+          attestations: false
         id: publish


### PR DESCRIPTION
Attestations became default-on in newer versions and fail because the OIDC certificate references release.yml (caller) while PyPI Trusted Publisher expects python-publish.yml (reusable workflow).