### PR TITLE
fix(ci): sign tags in skip-version-bump release path

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -170,6 +170,9 @@ jobs:
       - name: Version release (from pyproject.toml)
         if: inputs.publish-enabled && inputs.skip-version-bump
         id: release-current
+        env:
+          SSH_SIGN_KEY_PRIVATE: ${{ secrets.SSH_SIGN_KEY_PRIVATE }}
+          SSH_SIGN_KEY_PUBLIC: ${{ secrets.SSH_SIGN_KEY_PUBLIC }}
         run: |
           VERSION=$(poetry version -s)
           TAG="v${VERSION}"
@@ -177,8 +180,17 @@ jobs:
           git config user.name "bob-the-builder-ipor"
           git config user.email "106537082+bob-the-builder-ipor@users.noreply.github.com"
 
+          # SSH tag signing — parity with python-semantic-release path
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_SIGN_KEY_PRIVATE" > ~/.ssh/sign_key
+          printf '%s\n' "$SSH_SIGN_KEY_PUBLIC"  > ~/.ssh/sign_key.pub
+          chmod 600 ~/.ssh/sign_key ~/.ssh/sign_key.pub
+          git config --global gpg.format ssh
+          git config --global user.signingkey ~/.ssh/sign_key.pub
+          git config --global tag.gpgsign true
+
           poetry build
-          git tag -a "${TAG}" -m "${TAG}"
+          git tag -s -a "${TAG}" -m "${TAG}"
           git push origin "${TAG}"
 
           echo "released=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Tags `v2.0.0` and `v2.1.1` shipped **unverified** on GitHub because the `skip-version-bump: true` branch in `.github/workflows/python-publish.yml` ran a plain \`git tag -a\` with no signing configured.
- The `python-semantic-release` path (used by all other releases) already signs via \`ssh_public_signing_key\` / \`ssh_private_signing_key\` — those tags (e.g. `v2.1.0`, `v0.24.0`) are verified.
- This PR brings parity: load \`SSH_SIGN_KEY_PRIVATE\` / \`SSH_SIGN_KEY_PUBLIC\` into \`~/.ssh\`, set \`gpg.format=ssh\` + \`tag.gpgsign=true\`, and use \`git tag -s\`.

Existing unsigned tags (`v2.0.0`, `v2.1.1`) are left as-is — retagging would require a force-push and rewrite SHAs for anyone who already pulled.

## Test plan

- [ ] Trigger a release via `workflow_dispatch` with `skip-version-bump: true` (pre-bumping `pyproject.toml` manually, as for v2.1.1).
- [ ] Confirm the resulting tag on GitHub shows **Verified**.
- [ ] Confirm `git tag -v <tag>` against the allowed-signers file returns \`Good "..." signature\`.