### PR TITLE
feat(cli,mcp): migrate config_store and MCP tool I/O to Pydantic v2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3127,11 +3127,11 @@ multidict = ">=4.0"
 propcache = ">=0.2.0"
 
 [extras]
-cli = ["click", "requests"]
-mcp = ["click", "mcp", "requests"]
+cli = ["click", "pydantic", "requests"]
+mcp = ["click", "mcp", "pydantic", "requests"]
 testing = ["requests", "testcontainers"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "70822855e159f2f2d45c0cd8fc253bb84f0fccd076f89dbc9ddd6fcdc3bd7cce"
+content-hash = "a8a1559491bc8a6b51bf5e46d1ab5313dc0aaafc88c32bdebad24b4e5314319f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,11 @@ click = {version = "^8.0", optional = true}
 testcontainers = {version = "^4.8.2", optional = true}
 requests = {version = "^2.31.0", optional = true}
 mcp = {version = "^1.0", optional = true, extras = ["cli"]}
+pydantic = {version = "^2.10", optional = true}
 
 [tool.poetry.extras]
-cli = ["click", "requests"]
-mcp = ["mcp", "click", "requests"]
+cli = ["click", "requests", "pydantic"]
+mcp = ["mcp", "click", "requests", "pydantic"]
 testing = ["testcontainers", "requests"]
 
 [tool.poetry.dev-dependencies]

--- a/src/ipor_fusion/cli/config_store.py
+++ b/src/ipor_fusion/cli/config_store.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 import os
 import threading
-from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 import click
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 
 def _xdg_config_home() -> Path:
@@ -25,73 +25,49 @@ DEPLOYMENT_CACHE_FILE = CACHE_DIR / "deployment_cache.json"
 
 CONFIG_VERSION = 1
 
-_VAULT_REQUIRED_KEYS = {"address", "label", "chain_id"}
 
-
-@dataclass
-class VaultEntry:
+class VaultEntry(BaseModel):
     address: str
     label: str
     chain_id: int
 
 
-@dataclass
-class FusionConfig:
-    providers: dict[str, str] = field(default_factory=dict)
+class FusionConfig(BaseModel):
+    providers: dict[str, str] = Field(default_factory=dict)
     etherscan_api_key: str | None = None
-    vaults: list[VaultEntry] = field(default_factory=list)
+    vaults: list[VaultEntry] = Field(default_factory=list)
+    version: int = CONFIG_VERSION
 
-
-def _validate_config(data: object) -> dict:
-    """Validate config structure, raise click.ClickException on problems."""
-    hint = "Fix the file manually or delete it to start fresh."
-    if not isinstance(data, dict):
-        raise click.ClickException(f"Config {CONFIG_FILE} is not a JSON object. {hint}")
-    if "providers" in data and not isinstance(data["providers"], dict):
-        raise click.ClickException(
-            f"'providers' in {CONFIG_FILE} must be an object. {hint}"
-        )
-    if "vaults" in data and not isinstance(data["vaults"], list):
-        raise click.ClickException(f"'vaults' in {CONFIG_FILE} must be a list. {hint}")
-    for i, entry in enumerate(data.get("vaults", [])):
-        if not isinstance(entry, dict) or not _VAULT_REQUIRED_KEYS <= entry.keys():
-            raise click.ClickException(
-                f"Vault entry {i} in {CONFIG_FILE} must have keys "
-                f"{sorted(_VAULT_REQUIRED_KEYS)}. {hint}"
-            )
-    return data
-
-
-def _migrate_to_v1(data: dict) -> dict:
-    """Ensure all expected keys exist and set version to 1."""
-    data.setdefault("providers", {})
-    data.setdefault("etherscan_api_key", None)
-    data.pop("default_vault", None)
-    data.setdefault("vaults", [])
-    data["version"] = 1
-    return data
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy(cls, data: object) -> object:
+        # Drops fields removed in earlier migrations; missing keys fall back to
+        # the field defaults declared above.
+        if isinstance(data, dict):
+            data.pop("default_vault", None)
+        return data
 
 
 def load_config() -> FusionConfig:
     if not CONFIG_FILE.exists():
         return FusionConfig()
-    data = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
-    _validate_config(data)
-    if data.get("version") is None:
-        _migrate_to_v1(data)
-    vaults = [VaultEntry(**v) for v in data.get("vaults", [])]
-    return FusionConfig(
-        providers=data.get("providers", {}),
-        etherscan_api_key=data.get("etherscan_api_key"),
-        vaults=vaults,
-    )
+    try:
+        return FusionConfig.model_validate_json(CONFIG_FILE.read_text(encoding="utf-8"))
+    except ValidationError as exc:
+        raise click.ClickException(
+            f"Config {CONFIG_FILE} is invalid:\n{exc}\n"
+            "Fix the file manually or delete it to start fresh."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            f"Config {CONFIG_FILE} is not valid JSON: {exc}. "
+            "Fix the file manually or delete it to start fresh."
+        ) from exc
 
 
 def save_config(config: FusionConfig) -> None:
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    data = asdict(config)
-    data["version"] = CONFIG_VERSION
-    CONFIG_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    CONFIG_FILE.write_text(config.model_dump_json(indent=2), encoding="utf-8")
 
 
 _cache_lock = threading.Lock()

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -1,0 +1,207 @@
+"""Pydantic response models for MCP tools.
+
+Tool functions in mcp/server.py return instances of these models. FastMCP
+serializes them via model_dump() and exposes their JSON schema to the LLM.
+
+Design notes:
+- Top-level shapes are strictly typed for LLM schema clarity.
+- Truly dynamic sections (substrates keyed by market label, per-protocol
+  position breakdowns) use dict[str, Any] / list[dict[str, Any]] — modelling
+  every variant would be brittle without meaningful LLM-side benefit.
+- Models use extra="forbid": any new field added to _build_json_output that
+  is not declared here will fail VaultInfoResponse.model_validate(). This is
+  intentional — it forces CLI dict-builder and MCP model to stay in sync,
+  catching silent drift and typos at test time. See test_mcp_models.py for
+  the contract test that exercises every top-level field.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _Base(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# Shared building blocks
+# ---------------------------------------------------------------------------
+
+
+class Amount(_Base):
+    """Token amount with both raw and formatted representations."""
+
+    raw: int | str = Field(description="Raw on-chain integer (or 'unlimited').")
+    formatted: str = Field(description="Human-readable decimal string.")
+    usd: float | None = Field(
+        default=None, description="USD value; null when no oracle price."
+    )
+
+
+class AmountWithPercent(Amount):
+    percent: float | None = Field(
+        default=None, description="Delta as percent of on-chain total."
+    )
+
+
+class AssetInfo(_Base):
+    address: str
+    symbol: str
+    decimals: int
+    price_usd: float | None = Field(
+        default=None, description="Underlying-asset USD price; null when no oracle."
+    )
+
+
+class Managers(_Base):
+    access: str | None
+    price_oracle: str | None
+    rewards: str | None
+    withdraw: str | None
+
+
+class FuseEntry(_Base):
+    address: str
+    contract: str = Field(
+        description="Contract name resolved via Etherscan; '?' if unknown."
+    )
+
+
+class BalanceFuseEntry(_Base):
+    """A balance fuse entry with optional protocol-specific breakdown.
+
+    `position_breakdown` shape depends on the protocol (Morpho per-market or
+    Aave V3 per-asset) and is intentionally untyped here — it is rendered
+    verbatim from _build_json_output.
+    """
+
+    market: str
+    market_id: int
+    balance: Amount
+    fuse: str
+    contract: str
+    pct_of_total: float | None = Field(default=None)
+    depends_on: list[str] | None = Field(default=None)
+    position_breakdown: list[dict[str, Any]] | None = Field(default=None)
+
+
+class ERC20Entry(_Base):
+    """ERC-20 balance entry; field set varies by data availability."""
+
+    address: str
+    symbol: str
+    decimals: int | None = None
+    balance: Amount | None = None
+    price_usd: float | None = None
+    usd_value: float | None = None
+    note: str | None = None
+
+
+class Reconciliation(_Base):
+    balance_fuses_total: Amount
+    underlying_on_vault: Amount
+    erc20_direct_total: Amount
+    sum: Amount
+    on_chain_total_assets: Amount
+    delta: AmountWithPercent
+    pending_withdrawals: Amount
+    implied_market_total: Amount
+    market_storage_divergence: int
+
+
+class LendingMarketHealth(_Base):
+    protocol: str
+    market_id: str | int
+    market_name: str
+    current_ltv: float | None
+    max_ltv: float | None
+    health_factor: float | None
+    total_collateral_usd: float | None
+    total_debt_usd: float | None
+    ltv_usage_percent: float | None
+    is_warning: bool
+    is_critical: bool
+
+
+class LendingHealth(_Base):
+    markets: list[LendingMarketHealth]
+    worst_ltv_usage_percent: float | None
+
+
+class HealthCheck(_Base):
+    ok: bool
+    warnings: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Tool response models
+# ---------------------------------------------------------------------------
+
+
+class ActionResult(_Base):
+    """Generic 'operation succeeded' message with the human-readable detail."""
+
+    message: str
+
+
+class VaultListEntry(_Base):
+    address: str
+    label: str
+    chain: str
+    chain_id: int
+
+
+class ConfigShowResponse(_Base):
+    providers: dict[str, str] = Field(
+        description="Map of chain_id (string) to RPC provider URL."
+    )
+    vaults: list[VaultListEntry]
+    etherscan_api_key: str | None = Field(
+        default=None,
+        description="Masked ('***') when set, null when unset.",
+    )
+
+
+class VaultInfoResponse(_Base):
+    """Full on-chain state of a Plasma Vault.
+
+    Top-level fields are typed; deeply nested protocol-specific blocks
+    (substrates, position breakdowns inside balance_fuses, dependency_graph,
+    deployment, withdraw_manager_details, share_price) keep dict[str, Any]
+    typing because their shape is conditional on which protocols and managers
+    a given vault uses.
+    """
+
+    vault: str
+    name: str | None = None
+    links: dict[str, str] = Field(
+        description="External URLs (ipor_app, etherscan if known)."
+    )
+    chain: str
+    chain_id: int
+    block: int | str
+    block_timestamp: int
+    block_timestamp_utc: str
+    deployment: dict[str, Any] | None = None
+    asset: AssetInfo
+    share_decimals: int
+    total_assets: Amount
+    total_supply: Amount
+    share_price: dict[str, Any] | None = None
+    supply_cap: Amount
+    managers: Managers
+    withdraw_manager_details: dict[str, Any] | None = None
+    fuses: list[FuseEntry]
+    balance_fuses: list[BalanceFuseEntry]
+    instant_withdrawal_fuses: list[FuseEntry]
+    substrates: dict[str, list[dict[str, Any]]] = Field(
+        description="Per-market substrate entries; outer keys are human-readable market labels."
+    )
+    dependency_graph: dict[str, Any] | None = None
+    erc20_balances: list[ERC20Entry]
+    reconciliation: Reconciliation
+    lending_health: LendingHealth | None = None
+    health_check: HealthCheck

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -4,8 +4,6 @@ Calls the ipor_fusion SDK directly — no CLI subprocess.
 Configuration is loaded from the shared CLI config (~/.config/ipor-fusion/).
 """
 
-import json
-
 from mcp.server.fastmcp import FastMCP
 from web3 import Web3
 
@@ -25,6 +23,12 @@ from ipor_fusion.cli.vault_fetcher import (
 )
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
+from ipor_fusion.mcp.models import (
+    ActionResult,
+    ConfigShowResponse,
+    VaultInfoResponse,
+    VaultListEntry,
+)
 
 mcp = FastMCP("ipor-fusion")
 
@@ -80,45 +84,12 @@ def vault_info(
     vault_address: str,
     chain_id: int = 0,
     block_number: int = 0,
-) -> str:
-    """Get full on-chain state of a Plasma Vault (JSON).
+) -> VaultInfoResponse:
+    """Get full on-chain state of a Plasma Vault.
 
-    Returned JSON fields:
-    - vault, chain, chain_id, block, block_timestamp, block_timestamp_utc
-    - links (ipor_app URL, etherscan URL)
-    - deployment (deployer, deploy_block, deploy_timestamp, vault_age)
-    - asset (address, symbol, decimals, price_usd)
-    - share_decimals
-    - total_assets (raw, formatted, usd)
-    - total_supply (raw, formatted)
-    - supply_cap (raw, formatted)
-    - managers (access, price_oracle, rewards, withdraw)
-    - withdraw_manager_details — null when no withdraw manager:
-      withdraw_window_seconds, request_fee_wad/percent, withdraw_fee_wad/percent,
-      shares_to_release (raw/formatted), last_release_funds_timestamp/utc,
-      total_pending_shares (raw/formatted),
-      pending_requests[] (account, shares, assets with usd, end_withdraw_window, remaining_seconds, can_withdraw)
-    - fuses (address, contract name)
-    - instant_withdrawal_fuses (address, contract name)
-    - balance_fuses per market (market name, balance raw/formatted, fuse address/contract,
-      position_breakdown — for Morpho and Aave V3 markets: exposes the per-substrate
-      decomposition hidden behind the single netted balance fuse value. Each amount
-      object contains: raw (native on-chain integer), token (ERC-20 address),
-      symbol/decimals/formatted when ERC-20 metadata is resolvable, and usd when the
-      vault's price oracle has a source for that token.
-        - Morpho: list of per-morpho-market-id positions with morpho_market_id,
-          collateral_symbol, loan_symbol, and collateral/borrow/supply amount objects.
-        - Aave V3: list of per-asset positions with asset, asset_symbol, and
-          supply/variable_debt/stable_debt amount objects; only assets with non-zero
-          amounts are included.)
-    - substrates per market (address, symbol, contract, substrate_type)
-    - erc20_balances (address, symbol, decimals, balance, price_usd, usd_value)
-    - reconciliation (balance_fuses_total, underlying_on_vault, erc20_direct_total, sum, on_chain_total_assets, delta)
-    - lending_health — null when no lending positions:
-      markets[] (protocol, market_id, market_name, current_ltv, max_ltv, health_factor,
-      total_collateral_usd, total_debt_usd, ltv_usage_percent, is_warning, is_critical),
-      worst_ltv_usage_percent
-    - health_check (ok, warnings)
+    Returns a structured VaultInfoResponse — see model field descriptions
+    for the complete output schema (assets, balance fuses, reconciliation,
+    lending health, substrates, etc.).
 
     Args:
         vault_address: Vault address (required).
@@ -155,23 +126,22 @@ def vault_info(
     result = _build_json_output(
         ctx, plasma_vault, data, vault_address, chain_id, chain_label, api_key
     )
-    return json.dumps(result, indent=2)
+    return VaultInfoResponse.model_validate(result)
 
 
 @mcp.tool()
-def vault_list() -> str:
+def vault_list() -> list[VaultListEntry]:
     """List all saved Plasma Vaults with their chain, label, and address."""
     cfg = load_config()
-    entries = [
-        {
-            "address": v.address,
-            "label": v.label,
-            "chain": CHAIN_NAMES.get(v.chain_id, str(v.chain_id)),
-            "chain_id": v.chain_id,
-        }
+    return [
+        VaultListEntry(
+            address=v.address,
+            label=v.label,
+            chain=CHAIN_NAMES.get(v.chain_id, str(v.chain_id)),
+            chain_id=v.chain_id,
+        )
         for v in cfg.vaults
     ]
-    return json.dumps(entries, indent=2)
 
 
 @mcp.tool()
@@ -179,7 +149,7 @@ def vault_add(
     address: str,
     label: str = "",
     chain_id: int = 0,
-) -> str:
+) -> ActionResult:
     """Save a Plasma Vault to the local config.
 
     Args:
@@ -212,15 +182,15 @@ def vault_add(
             vault_entry.label = label
             vault_entry.chain_id = chain_id
             save_config(cfg)
-            return f"Vault {label} ({address}) updated."
+            return ActionResult(message=f"Vault {label} ({address}) updated.")
 
     cfg.vaults.append(VaultEntry(address=address, label=label, chain_id=chain_id))
     save_config(cfg)
-    return f"Vault {label} ({address}) added."
+    return ActionResult(message=f"Vault {label} ({address}) added.")
 
 
 @mcp.tool()
-def vault_remove(address: str) -> str:
+def vault_remove(address: str) -> ActionResult:
     """Remove a Plasma Vault from the local config.
 
     Args:
@@ -230,9 +200,9 @@ def vault_remove(address: str) -> str:
     before = len(cfg.vaults)
     cfg.vaults = [v for v in cfg.vaults if v.address.lower() != address.lower()]
     if len(cfg.vaults) == before:
-        return "Vault not found."
+        return ActionResult(message="Vault not found.")
     save_config(cfg)
-    return "Vault removed."
+    return ActionResult(message="Vault removed.")
 
 
 # ---------------------------------------------------------------------------
@@ -241,31 +211,30 @@ def vault_remove(address: str) -> str:
 
 
 @mcp.tool()
-def config_show() -> str:
+def config_show() -> ConfigShowResponse:
     """Show current fusion CLI configuration.
 
     Displays configured RPC providers, saved vaults,
     and Etherscan API key status.
     """
     cfg = load_config()
-    result = {
-        "providers": dict(cfg.providers),
-        "vaults": [
-            {
-                "chain_id": v.chain_id,
-                "chain": CHAIN_NAMES.get(v.chain_id, str(v.chain_id)),
-                "label": v.label,
-                "address": v.address,
-            }
+    return ConfigShowResponse(
+        providers=dict(cfg.providers),
+        vaults=[
+            VaultListEntry(
+                address=v.address,
+                label=v.label,
+                chain=CHAIN_NAMES.get(v.chain_id, str(v.chain_id)),
+                chain_id=v.chain_id,
+            )
             for v in cfg.vaults
         ],
-        "etherscan_api_key": "***" if cfg.etherscan_api_key else None,
-    }
-    return json.dumps(result, indent=2)
+        etherscan_api_key="***" if cfg.etherscan_api_key else None,
+    )
 
 
 @mcp.tool()
-def config_set_provider(url: str, chain_id: int = 0) -> str:
+def config_set_provider(url: str, chain_id: int = 0) -> ActionResult:
     """Set RPC provider URL for a chain.
 
     Args:
@@ -279,11 +248,11 @@ def config_set_provider(url: str, chain_id: int = 0) -> str:
     cfg = load_config()
     cfg.providers[str(chain_id)] = url
     save_config(cfg)
-    return f"Provider for chain {chain_id} set."
+    return ActionResult(message=f"Provider for chain {chain_id} set.")
 
 
 @mcp.tool()
-def config_set_etherscan_key(api_key: str) -> str:
+def config_set_etherscan_key(api_key: str) -> ActionResult:
     """Set Etherscan API key (works for all chains via Etherscan V2).
 
     Args:
@@ -292,7 +261,7 @@ def config_set_etherscan_key(api_key: str) -> str:
     cfg = load_config()
     cfg.etherscan_api_key = api_key
     save_config(cfg)
-    return "Etherscan API key set."
+    return ActionResult(message="Etherscan API key set.")
 
 
 def main() -> None:

--- a/tests/test_cli_config_store.py
+++ b/tests/test_cli_config_store.py
@@ -177,6 +177,30 @@ class TestLoadConfigValidation:
             load_config()
 
 
+class TestLegacyMigration:
+    def test_drops_legacy_default_vault_field(self, tmp_path):
+        config_dir = tmp_path / ".fusion"
+        config_dir.mkdir()
+        data = {
+            "providers": {"1": "http://localhost:8545"},
+            "default_vault": "0xLEGACY",
+            "vaults": [],
+        }
+        (config_dir / "config.json").write_text(json.dumps(data), encoding="utf-8")
+
+        cfg = load_config()
+
+        assert not hasattr(cfg, "default_vault")
+        assert cfg.providers == {"1": "http://localhost:8545"}
+
+    def test_invalid_json_raises_click_exception(self, tmp_path):
+        config_dir = tmp_path / ".fusion"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text("{not valid json", encoding="utf-8")
+        with pytest.raises(click.ClickException):
+            load_config()
+
+
 class TestConfigVersioning:
     def test_save_config_writes_version(self, tmp_path):
         save_config(FusionConfig())

--- a/tests/test_mcp_models.py
+++ b/tests/test_mcp_models.py
@@ -1,0 +1,267 @@
+"""Contract tests for mcp/models.py.
+
+Models use extra="forbid", so the test below must mirror the full shape that
+cli/vault_cmd.py::_build_json_output produces. If you add a top-level key
+there, this test will fail until the model is updated. That is the point.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ipor_fusion.mcp.models import (
+    Amount,
+    ConfigShowResponse,
+    Reconciliation,
+    VaultInfoResponse,
+    VaultListEntry,
+)
+
+
+def _amount(raw: int = 0, formatted: str = "0", usd: float | None = None) -> dict:
+    return {"raw": raw, "formatted": formatted, "usd": usd}
+
+
+def _full_vault_info_dict() -> dict:
+    """Mirror of cli/vault_cmd.py::_build_json_output with every optional
+    block populated (lending positions, withdraw manager, substrates with
+    address+symbol+contract, balance fuses with both Morpho and Aave
+    position breakdowns, ERC20 with full token detail). Keep in sync with
+    the dict literal at the bottom of _build_json_output."""
+    return {
+        "vault": "0xVAULT",
+        "name": "Test Vault",
+        "links": {
+            "ipor_app": "https://app.ipor.io/ethereum/0xVAULT",
+            "etherscan": "https://etherscan.io/address/0xVAULT",
+        },
+        "chain": "ethereum",
+        "chain_id": 1,
+        "block": 12345,
+        "block_timestamp": 1700000000,
+        "block_timestamp_utc": "2023-11-14T22:13:20Z",
+        "deployment": {
+            "deployer": "0xDEPLOYER",
+            "deploy_block": 1000,
+            "deploy_timestamp": 1600000000,
+            "vault_age": "100d",
+        },
+        "asset": {
+            "address": "0xUSDC",
+            "symbol": "USDC",
+            "decimals": 6,
+            "price_usd": 1.0,
+        },
+        "share_decimals": 18,
+        "total_assets": _amount(1_000_000_000, "1000.0", 1000.0),
+        "total_supply": _amount(1_000_000_000_000_000_000_000, "1000.0", None),
+        "share_price": {"raw": 10**18, "formatted": "1.0"},
+        "supply_cap": _amount(2**256 - 1, "unlimited", None),
+        "managers": {
+            "access": "0xACCESS",
+            "price_oracle": "0xORACLE",
+            "rewards": "0xREWARDS",
+            "withdraw": "0xWITHDRAW",
+        },
+        "withdraw_manager_details": {
+            "withdraw_window_seconds": 86400,
+            "request_fee_wad": 0,
+            "withdraw_fee_wad": 0,
+            "shares_to_release": _amount(0, "0"),
+            "last_release_funds_timestamp": 1700000000,
+            "last_release_funds_timestamp_utc": "2023-11-14T22:13:20Z",
+            "total_pending_shares": _amount(0, "0"),
+            "pending_requests": [],
+        },
+        "fuses": [
+            {"address": "0xFUSE1", "contract": "MorphoSupplyFuse"},
+        ],
+        "balance_fuses": [
+            {
+                "market": "MORPHO (1)",
+                "market_id": 1,
+                "balance": _amount(500_000_000, "500.0", 500.0),
+                "fuse": "0xBF1",
+                "contract": "MorphoBalanceFuse",
+                "pct_of_total": 50.0,
+                "depends_on": ["AAVE_V3 (2)"],
+                "position_breakdown": [
+                    {
+                        "morpho_market_id": "0xMID",
+                        "collateral_symbol": "WETH",
+                        "loan_symbol": "USDC",
+                        "collateral": {
+                            "raw": 1,
+                            "token": "0xWETH",
+                            "symbol": "WETH",
+                            "decimals": 18,
+                            "formatted": "0.000000000000000001",
+                            "usd": 0.0,
+                        },
+                        "borrow": {"raw": 0, "token": "0xUSDC"},
+                        "supply": {"raw": 0, "token": "0xUSDC"},
+                    }
+                ],
+            },
+            {
+                "market": "AAVE_V3 (2)",
+                "market_id": 2,
+                "balance": _amount(300_000_000, "300.0", 300.0),
+                "fuse": "0xBF2",
+                "contract": "AaveV3BalanceFuse",
+                "pct_of_total": 30.0,
+                "position_breakdown": [
+                    {
+                        "asset": "0xUSDC",
+                        "asset_symbol": "USDC",
+                        "supply": {"raw": 100, "token": "0xUSDC"},
+                        "variable_debt": {"raw": 0, "token": "0xUSDC"},
+                        "stable_debt": {"raw": 0, "token": "0xUSDC"},
+                    }
+                ],
+            },
+        ],
+        "instant_withdrawal_fuses": [
+            {"address": "0xIW1", "contract": "ERC4626SupplyFuse"},
+        ],
+        "substrates": {
+            "MORPHO (1)": [
+                {
+                    "address": "0xSUB",
+                    "symbol": "WETH",
+                    "contract": "WETH",
+                    "substrate_type": "erc20",
+                }
+            ],
+        },
+        "dependency_graph": {"1": [2]},
+        "erc20_balances": [
+            {
+                "address": "0xUSDC",
+                "symbol": "USDC",
+                "decimals": 6,
+                "balance": _amount(100, "0.0001", 0.0001),
+                "price_usd": 1.0,
+                "usd_value": 0.0001,
+                "note": "ok",
+            }
+        ],
+        "reconciliation": {
+            "balance_fuses_total": _amount(800_000_000, "800.0", 800.0),
+            "underlying_on_vault": _amount(100, "0.0001", 0.0001),
+            "erc20_direct_total": _amount(100, "0.0001", 0.0001),
+            "sum": _amount(800_000_100, "800.0001", 800.0001),
+            "on_chain_total_assets": _amount(800_000_100, "800.0001", 800.0001),
+            "delta": {"raw": 0, "formatted": "0.0", "usd": 0.0, "percent": 0.0},
+            "pending_withdrawals": _amount(0, "0", 0.0),
+            "implied_market_total": {"raw": 800_000_000, "formatted": "800.0"},
+            "market_storage_divergence": 0,
+        },
+        "lending_health": {
+            "markets": [
+                {
+                    "protocol": "morpho",
+                    "market_id": "0xMID",
+                    "market_name": "WETH/USDC",
+                    "current_ltv": 0.5,
+                    "max_ltv": 0.86,
+                    "health_factor": 1.72,
+                    "total_collateral_usd": 1000.0,
+                    "total_debt_usd": 500.0,
+                    "ltv_usage_percent": 58.1,
+                    "is_warning": False,
+                    "is_critical": False,
+                }
+            ],
+            "worst_ltv_usage_percent": 58.1,
+        },
+        "health_check": {"ok": True, "warnings": []},
+    }
+
+
+class TestVaultInfoResponseContract:
+    def test_full_dict_validates(self):
+        result = VaultInfoResponse.model_validate(_full_vault_info_dict())
+        assert result.vault == "0xVAULT"
+        assert result.balance_fuses[0].position_breakdown is not None
+        assert result.lending_health is not None
+        assert result.reconciliation.delta.percent == 0.0
+
+    def test_minimal_dict_validates(self):
+        """All optional sections set to None/empty."""
+        d = _full_vault_info_dict()
+        d["name"] = None
+        d["deployment"] = None
+        d["share_price"] = None
+        d["withdraw_manager_details"] = None
+        d["dependency_graph"] = None
+        d["lending_health"] = None
+        d["balance_fuses"] = []
+        d["substrates"] = {}
+        d["erc20_balances"] = []
+        d["fuses"] = []
+        d["instant_withdrawal_fuses"] = []
+        VaultInfoResponse.model_validate(d)
+
+    def test_unknown_top_level_key_rejected(self):
+        d = _full_vault_info_dict()
+        d["unexpected_field"] = "drift"
+        with pytest.raises(ValidationError):
+            VaultInfoResponse.model_validate(d)
+
+    def test_unknown_amount_field_rejected(self):
+        d = _full_vault_info_dict()
+        d["total_assets"]["new_metric"] = 42
+        with pytest.raises(ValidationError):
+            VaultInfoResponse.model_validate(d)
+
+    def test_round_trip_preserves_shape(self):
+        original = _full_vault_info_dict()
+        model = VaultInfoResponse.model_validate(original)
+        round_tripped = model.model_dump(mode="json")
+        assert round_tripped["balance_fuses"][0]["balance"]["usd"] == 500.0
+        assert round_tripped["reconciliation"]["delta"]["percent"] == 0.0
+
+
+class TestSimpleResponseContracts:
+    def test_config_show_round_trip(self):
+        d = {
+            "providers": {"1": "https://rpc.example.com"},
+            "vaults": [
+                {
+                    "address": "0xABC",
+                    "label": "main",
+                    "chain": "ethereum",
+                    "chain_id": 1,
+                }
+            ],
+            "etherscan_api_key": "***",
+        }
+        ConfigShowResponse.model_validate(d)
+
+    def test_amount_rejects_unknown_field(self):
+        with pytest.raises(ValidationError):
+            Amount.model_validate({"raw": 1, "formatted": "1", "extra": "no"})
+
+    def test_vault_list_entry_round_trip(self):
+        VaultListEntry.model_validate(
+            {"address": "0xA", "label": "x", "chain": "base", "chain_id": 8453}
+        )
+
+    def test_reconciliation_with_no_usd_in_implied_market_total(self):
+        """implied_market_total is the only Amount in reconciliation_json that
+        omits the 'usd' key. Verify Amount.usd defaults to None."""
+        d = {
+            "balance_fuses_total": {"raw": 1, "formatted": "1", "usd": 1.0},
+            "underlying_on_vault": {"raw": 0, "formatted": "0", "usd": 0.0},
+            "erc20_direct_total": {"raw": 0, "formatted": "0", "usd": 0.0},
+            "sum": {"raw": 1, "formatted": "1", "usd": 1.0},
+            "on_chain_total_assets": {"raw": 1, "formatted": "1", "usd": 1.0},
+            "delta": {"raw": 0, "formatted": "0", "usd": 0.0, "percent": 0.0},
+            "pending_withdrawals": {"raw": 0, "formatted": "0", "usd": 0.0},
+            "implied_market_total": {"raw": 1, "formatted": "1"},
+            "market_storage_divergence": 0,
+        }
+        recon = Reconciliation.model_validate(d)
+        assert recon.implied_market_total.usd is None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,7 +1,6 @@
 # pylint: disable=unused-argument,import-outside-toplevel
 """Tests for the MCP server tool definitions (direct SDK import)."""
 
-import json
 from unittest.mock import MagicMock, patch
 
 from ipor_fusion.mcp.server import (
@@ -38,16 +37,16 @@ def _config_with_vault():
 class TestConfigShow:
     @patch("ipor_fusion.mcp.server.load_config", return_value=_empty_config())
     def test_empty_config(self, _):
-        result = json.loads(config_show())
-        assert result["providers"] == {}
-        assert result["vaults"] == []
-        assert result["etherscan_api_key"] is None
+        result = config_show()
+        assert result.providers == {}
+        assert result.vaults == []
+        assert result.etherscan_api_key is None
 
     @patch("ipor_fusion.mcp.server.load_config", return_value=_config_with_vault())
     def test_config_with_vault(self, _):
-        result = json.loads(config_show())
-        assert len(result["vaults"]) == 1
-        assert result["vaults"][0]["address"] == "0xABC"
+        result = config_show()
+        assert len(result.vaults) == 1
+        assert result.vaults[0].address == "0xABC"
 
 
 class TestConfigSetProvider:
@@ -55,7 +54,7 @@ class TestConfigSetProvider:
     @patch("ipor_fusion.mcp.server.load_config", return_value=_empty_config())
     def test_with_chain_id(self, mock_load, mock_save):
         result = config_set_provider(url="https://rpc.example.com", chain_id=1)
-        assert "chain 1" in result.lower()
+        assert "chain 1" in result.message.lower()
         saved_cfg = mock_save.call_args[0][0]
         assert saved_cfg.providers["1"] == "https://rpc.example.com"
 
@@ -69,7 +68,7 @@ class TestConfigSetProvider:
         mock_web3.HTTPProvider = MagicMock()
 
         result = config_set_provider(url="https://rpc.example.com")
-        assert "42161" in result
+        assert "42161" in result.message
         saved_cfg = mock_save.call_args[0][0]
         assert saved_cfg.providers["42161"] == "https://rpc.example.com"
 
@@ -79,7 +78,7 @@ class TestConfigSetEtherscanKey:
     @patch("ipor_fusion.mcp.server.load_config", return_value=_empty_config())
     def test_sets_key(self, mock_load, mock_save):
         result = config_set_etherscan_key(api_key="ABC123")
-        assert "set" in result.lower()
+        assert "set" in result.message.lower()
         saved_cfg = mock_save.call_args[0][0]
         assert saved_cfg.etherscan_api_key == "ABC123"
 
@@ -87,16 +86,16 @@ class TestConfigSetEtherscanKey:
 class TestVaultList:
     @patch("ipor_fusion.mcp.server.load_config", return_value=_empty_config())
     def test_empty(self, _):
-        result = json.loads(vault_list())
+        result = vault_list()
         assert result == []
 
     @patch("ipor_fusion.mcp.server.load_config", return_value=_config_with_vault())
     def test_with_vault(self, _):
-        result = json.loads(vault_list())
+        result = vault_list()
         assert len(result) == 1
-        assert result[0]["address"] == "0xABC"
-        assert result[0]["label"] == "Test"
-        assert result[0]["chain_id"] == 1
+        assert result[0].address == "0xABC"
+        assert result[0].label == "Test"
+        assert result[0].chain_id == 1
 
 
 class TestVaultAdd:
@@ -107,7 +106,7 @@ class TestVaultAdd:
     )
     def test_add_with_label_and_chain(self, mock_load, mock_save):
         result = vault_add(address="0xDEF", label="New Vault", chain_id=1)
-        assert "added" in result.lower()
+        assert "added" in result.message.lower()
         saved_cfg = mock_save.call_args[0][0]
         assert any(v.address == "0xDEF" for v in saved_cfg.vaults)
 
@@ -118,7 +117,7 @@ class TestVaultAdd:
     )
     def test_update_existing(self, mock_load, mock_save):
         result = vault_add(address="0xABC", label="Updated", chain_id=1)
-        assert "updated" in result.lower()
+        assert "updated" in result.message.lower()
         saved_cfg = mock_save.call_args[0][0]
         assert len(saved_cfg.vaults) == 1
         assert saved_cfg.vaults[0].label == "Updated"
@@ -132,7 +131,7 @@ class TestVaultRemove:
     )
     def test_remove_existing(self, mock_load, mock_save):
         result = vault_remove(address="0xABC")
-        assert "removed" in result.lower()
+        assert "removed" in result.message.lower()
         saved_cfg = mock_save.call_args[0][0]
         assert len(saved_cfg.vaults) == 0
 
@@ -142,4 +141,4 @@ class TestVaultRemove:
     )
     def test_remove_missing(self, _):
         result = vault_remove(address="0xNONEXISTENT")
-        assert "not found" in result.lower()
+        assert "not found" in result.message.lower()


### PR DESCRIPTION
## Summary

- `cli/config_store.py` migrates `VaultEntry`/`FusionConfig` from `@dataclass` to Pydantic v2 `BaseModel`. Manual `_validate_config` + `_migrate_to_v1` collapse into `model_validator(mode=\"before\")` and Pydantic's own validation. Backward-compat with legacy config files preserved.
- New `src/ipor_fusion/mcp/models.py` defines strict Pydantic response models for every MCP tool. Tools return model instances; FastMCP serializes via `model_dump()` and exposes `model_json_schema()` as the tool `outputSchema` — previously empty for `str`-returning tools.
- `extra=\"forbid\"` on every model. Any new field added to `cli/vault_cmd.py::_build_json_output` that is not declared in `mcp/models.py` will fail the contract test in `tests/test_mcp_models.py`. This forces the dict-builder and the MCP model to stay in sync.

## Why

LLMs consuming the IPOR Fusion MCP server previously had to read a long manual docstring listing every output field of `vault_info`. With this change the tool's `outputSchema` is auto-generated from `VaultInfoResponse`, including field-level descriptions. For the config layer the win is smaller but still real: structured `ValidationError` instead of three hand-rolled `isinstance` checks.

## Out of scope

- `FuseAction` and the fuses package — `frozen=True, slots=True` dataclass is the right tool for a hot-path immutable payload built in batches; Pydantic would regress perf with no validation gain.
- Reader response dataclasses — populated from positional `eth_abi.decode()` tuples, not JSON; near-zero validation gain.
- Public SDK surface (`PlasmaVault`, `Web3Context`, fuses, readers, `types.py`) — unchanged.

## Pydantic dependency placement

Added under `[cli]` and `[mcp]` extras only. Bare \`pip install ipor-fusion\` does not pull pydantic from us. (Pydantic happens to already be a transitive dep of web3 7.x, but that is web3's concern, not ours.)

## Test plan

- [x] `poetry run pytest tests/test_cli_config_store.py tests/test_mcp_server.py tests/test_mcp_models.py tests/test_cli_commands.py tests/test_cli_helpers.py tests/test_cli_explorer.py` — 238 passed
- [x] `poetry run mypy src/ipor_fusion/mcp/ src/ipor_fusion/cli/config_store.py` — clean
- [x] `poetry run pylint src/ipor_fusion/mcp/ src/ipor_fusion/cli/config_store.py` — 10/10
- [x] `poetry run black --check ...` — formatted
- [x] FastMCP `outputSchema` populated for all 7 tools (verified via `mcp.list_tools()`)
- [x] Round-trip: `model_dump(mode=\"json\")` produces identical shape to the previous hand-built dict
- [x] Bare-install: \`from ipor_fusion import PlasmaVault\` works without `[cli]/[mcp]` extras
- [ ] CI on this PR
- [ ] Manual MCP smoke test against a known vault (`fusion-mcp` under MCP Inspector) — to confirm `vault_info` serialization end-to-end with a live RPC