### PR TITLE
feat(cli,mcp): orphan-fuse detection + morpho-blue market explorer

### DIFF
--- a/src/ipor_fusion/__init__.py
+++ b/src/ipor_fusion/__init__.py
@@ -14,6 +14,7 @@ from ipor_fusion.core.oracle import PriceOracleMiddleware, AssetPriceSource
 from ipor_fusion.readers import (
     MorphoReader,
     MorphoMarket,
+    MorphoMarketRates,
     MorphoPosition,
     MorphoMarketParams,
     AaveV3Reader,
@@ -153,6 +154,7 @@ __all__ = [
     "MAX_UINT256",
     "MorphoReader",
     "MorphoMarket",
+    "MorphoMarketRates",
     "MorphoPosition",
     "MorphoMarketParams",
     "AaveV3Reader",

--- a/src/ipor_fusion/cli/explorer.py
+++ b/src/ipor_fusion/cli/explorer.py
@@ -48,18 +48,23 @@ def get_contract_name(chain_id: int, address: str, api_key: str | None = None) -
 
 def get_deployment_tx(
     chain_id: int, address: str, api_key: str | None = None
-) -> str | None:
-    """Return the creation tx hash for a contract."""
+) -> tuple[str | None, str | None]:
+    """Return ``(tx_hash, error)`` for a contract deployment.
+
+    ``error`` is a short machine-readable code when ``tx_hash`` is None and the
+    failure has a known cause; ``None`` means either success or a benign empty
+    result (e.g. Etherscan responded with "No data found").
+    """
     return _fetch_contract_creation_tx(chain_id, address, api_key)
 
 
 def _fetch_contract_creation_tx(
     chain_id: int, address: str, api_key: str | None = None
-) -> str | None:
+) -> tuple[str | None, str | None]:
     if chain_id not in SUPPORTED_CHAINS:
-        return None
+        return None, "chain-not-supported"
     if not api_key:
-        return None
+        return None, "no-api-key"
 
     params: dict[str, str] = {
         "chainid": str(chain_id),
@@ -70,20 +75,27 @@ def _fetch_contract_creation_tx(
     }
 
     url = f"{ETHERSCAN_V2_URL}?{urlencode(params)}"
+    last_error: str | None = "fetch-failed"
     for attempt in range(_MAX_RETRIES):
         _etherscan_limiter.wait()
         try:
             with urlopen(url, timeout=10) as resp:  # noqa: S310
                 data = json.loads(resp.read().decode())
             if data.get("status") == "1" and data.get("result"):
-                return data["result"][0].get("txHash")  # type: ignore[no-any-return]
-            if "rate limit" in str(data.get("result", "")).lower():
+                return data["result"][0].get("txHash"), None  # type: ignore[no-any-return]
+            result_text = str(data.get("result", "")).lower()
+            if "free api access is not supported" in result_text:
+                return None, "etherscan-paid-tier-required"
+            if "rate limit" in result_text:
+                last_error = "rate-limited"
                 time.sleep(_RETRY_DELAY * (attempt + 1))
                 continue
+            # status=0 with "No data found" — benign, no error
+            last_error = None
         except (OSError, json.JSONDecodeError, KeyError, IndexError):
-            pass
+            last_error = "fetch-failed"
         break
-    return None
+    return None, last_error
 
 
 def _fetch_getsourcecode(

--- a/src/ipor_fusion/cli/main.py
+++ b/src/ipor_fusion/cli/main.py
@@ -6,6 +6,7 @@ import sys
 import click
 
 from ipor_fusion.cli.config_cmd import config
+from ipor_fusion.cli.market_cmd import market
 from ipor_fusion.cli.vault_cmd import vault
 
 
@@ -28,6 +29,7 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool, no_color: bool) -> None:
 
 
 cli.add_command(config)
+cli.add_command(market)
 cli.add_command(vault)
 
 

--- a/src/ipor_fusion/cli/market_cmd.py
+++ b/src/ipor_fusion/cli/market_cmd.py
@@ -1,0 +1,770 @@
+"""`fusion market` command group — protocol-level market inspection.
+
+Currently exposes `morpho-blue <marketId>`: fetches a Morpho Blue market's
+parameters and state (loan/collateral/oracle/IRM/LLTV, totals, liquidity, APYs)
+plus the MetaMorpho vaults supplying it (current allocation, supply caps, and
+PublicAllocator flow caps + fees). Combines on-chain reads via `MorphoReader`
+with the Morpho public GraphQL API for vault discovery.
+"""
+
+from __future__ import annotations
+
+import json as json_lib
+
+import click
+
+from ipor_fusion.cli.config_store import load_config
+from ipor_fusion.cli.morpho_api import (
+    PUBLIC_ALLOCATOR_ADDRESSES,
+    MorphoApiError,
+    MorphoApiMarket,
+    VaultAllocation,
+    VaultV1Info,
+    VaultV2Cap,
+    VaultV2Info,
+    fetch_market,
+    fetch_vault,
+)
+from ipor_fusion.cli.vault_cmd import (
+    ADDRESS,
+    BLOCK_EXPLORER_URLS,
+    CHAIN,
+    CHAIN_NAMES,
+    _resolve_provider,
+)
+from ipor_fusion.cli.vault_rendering import _format_amount, _print_table
+from ipor_fusion.core.context import Web3Context
+from ipor_fusion.readers.lending_health import MORPHO_BLUE_ADDRESS
+from ipor_fusion.readers.morpho import (
+    WAD,
+    MorphoMarket,
+    MorphoMarketParams,
+    MorphoMarketRates,
+    MorphoReader,
+)
+from ipor_fusion.types import MorphoBlueMarketId
+
+
+class MarketIdType(click.ParamType):
+    """A 32-byte Morpho market ID (64 hex chars, with or without 0x prefix)."""
+
+    name = "marketId"
+
+    def convert(self, value, param, ctx):  # type: ignore[override]
+        if not isinstance(value, str):
+            self.fail(f"expected string, got {type(value).__name__}", param, ctx)
+        raw = value.strip().removeprefix("0x").removeprefix("0X")
+        if len(raw) != 64 or not all(c in "0123456789abcdefABCDEF" for c in raw):
+            self.fail(
+                f"invalid Morpho market ID (expected 32-byte hex): {value}", param, ctx
+            )
+        return raw.lower()
+
+
+MARKET_ID = MarketIdType()
+
+
+@click.group()
+def market() -> None:
+    """Inspect lending markets across protocols."""
+
+
+@market.command("morpho-blue")
+@click.argument("market_id", type=MARKET_ID)
+@click.option(
+    "--chain",
+    "chain_id",
+    type=CHAIN,
+    required=True,
+    help="Chain ID or name (ethereum, base, arbitrum, ...).",
+)
+@click.option(
+    "--block",
+    type=int,
+    default=None,
+    help="Block number for on-chain reads (default: latest).",
+)
+@click.option(
+    "--no-api",
+    is_flag=True,
+    default=False,
+    help="Skip Morpho API call (no vault discovery, no PublicAllocator info).",
+)
+@click.option(
+    "--vault",
+    "vault_filter",
+    type=ADDRESS,
+    default=None,
+    help="Show only this vault in the connected-vaults section.",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a table.",
+)
+def morpho_blue(
+    market_id: str,
+    chain_id: int,
+    block: int | None,
+    no_api: bool,
+    vault_filter: str | None,
+    json_output: bool,
+) -> None:
+    """Inspect a Morpho Blue market by its 32-byte market ID.
+
+    Returns market parameters (loan/collateral/oracle/IRM/LLTV), on-chain totals
+    + liquidity + APYs, and — unless --no-api is set — the list of MetaMorpho
+    vaults supplying this market with their PublicAllocator config (so you can
+    see which vault to call `reallocateTo` on, with what fee, and up to what
+    flow cap).
+    """
+    cfg = load_config()
+    provider_url = _resolve_provider(cfg, chain_id)
+    ctx = Web3Context.from_url(provider_url)
+    if block is not None:
+        ctx.default_block = block
+    reader = MorphoReader(ctx, MORPHO_BLUE_ADDRESS)
+    mid = MorphoBlueMarketId(market_id)
+    params = reader.market_params(mid)
+    state = reader.market(mid)
+    rates = reader.rates_from(state, params)
+
+    api_market: MorphoApiMarket | None = None
+    api_error: str | None = None
+    if not no_api:
+        try:
+            api_market = fetch_market(market_id, chain_id)
+        except MorphoApiError as exc:
+            api_error = str(exc)
+
+    public_allocator = PUBLIC_ALLOCATOR_ADDRESSES.get(chain_id)
+
+    if json_output:
+        click.echo(
+            json_lib.dumps(
+                _build_json(
+                    market_id,
+                    chain_id,
+                    params,
+                    state,
+                    rates,
+                    api_market,
+                    api_error,
+                    public_allocator,
+                ),
+                indent=2,
+            )
+        )
+        return
+
+    _print_market(market_id, chain_id, params, state, rates, public_allocator)
+    if no_api:
+        click.echo("\nConnected vaults: skipped (--no-api).")
+        return
+    if api_error:
+        click.secho(f"\nConnected vaults: unavailable ({api_error}).", fg="yellow")
+        return
+    assert api_market is not None
+    _print_vaults(api_market, vault_filter, params, public_allocator)
+
+
+def _print_market(
+    market_id: str,
+    chain_id: int,
+    params: MorphoMarketParams,
+    state: MorphoMarket,
+    rates: MorphoMarketRates,
+    public_allocator: str | None,
+) -> None:
+    chain_name = CHAIN_NAMES.get(chain_id, str(chain_id))
+    explorer = BLOCK_EXPLORER_URLS.get(chain_id, "")
+    liquidity = state.total_supply_assets - state.total_borrow_assets
+    click.secho(f"Morpho Blue market 0x{market_id}", bold=True)
+    click.echo(f"  Chain:           {chain_name} (id {chain_id})")
+    if explorer:
+        click.echo(
+            f"  App:             https://app.morpho.org/{chain_name}/market/0x{market_id}"
+        )
+    click.echo(f"  Loan token:      {params.loan_token}")
+    click.echo(f"  Collateral:      {params.collateral_token}")
+    click.echo(f"  Oracle:          {params.oracle}")
+    click.echo(f"  IRM:             {params.irm}")
+    click.echo(f"  LLTV:            {params.lltv / WAD * 100:.2f}%")
+    if public_allocator:
+        click.echo(f"  PublicAllocator: {public_allocator}")
+    else:
+        click.echo("  PublicAllocator: (not deployed on this chain)")
+    click.echo("")
+    click.echo("State (on-chain):")
+    click.echo(f"  Total supply:    {state.total_supply_assets:,} (raw)")
+    click.echo(f"  Total borrow:    {state.total_borrow_assets:,} (raw)")
+    click.echo(f"  Liquidity:       {liquidity:,} (raw)")
+    click.echo(f"  Utilization:     {rates.utilization * 100:.2f}%")
+    click.echo(f"  Borrow APY:      {rates.borrow_apy * 100:.2f}%")
+    click.echo(f"  Supply APY:      {rates.supply_apy * 100:.2f}%")
+    click.echo(f"  Protocol fee:    {state.fee / WAD * 100:.2f}%")
+
+
+def _print_vaults(
+    api_market: MorphoApiMarket,
+    vault_filter: str | None,
+    params: MorphoMarketParams,
+    public_allocator: str | None,
+) -> None:
+    decimals = api_market.loan_decimals
+    symbol = api_market.loan_symbol or "loan"
+    click.echo("")
+    click.secho(f"Connected MetaMorpho vaults ({len(api_market.vaults)}):", bold=True)
+    if not api_market.vaults:
+        click.echo("  (none — no vault has this market in its supplyQueue)")
+        click.echo("")
+        click.echo("Reallocate parameters (MarketParams):")
+        _print_reallocate_hint(params)
+        return
+
+    matched = [
+        v
+        for v in api_market.vaults
+        if not vault_filter or v.vault_address.lower() == vault_filter.lower()
+    ]
+    if not matched:
+        click.echo(f"  (no match for --vault {vault_filter})")
+        click.echo("")
+        click.echo("Reallocate parameters (MarketParams):")
+        _print_reallocate_hint(params)
+        return
+
+    summary_rows = [_vault_row(v, decimals, symbol, public_allocator) for v in matched]
+    _print_table(
+        ("Vault", "Address", "Allocation", "Cap", "Public reallocate"),
+        summary_rows,
+    )
+    click.echo("")
+    for vault in matched:
+        _print_vault_allocators(vault, public_allocator)
+    click.echo("Reallocate parameters (MarketParams):")
+    _print_reallocate_hint(params)
+
+
+def _vault_row(
+    vault: VaultAllocation,
+    loan_decimals: int,
+    loan_symbol: str,
+    public_allocator: str | None,
+) -> tuple[str, ...]:
+    alloc = f"{_format_amount(vault.supply_assets, loan_decimals)} {loan_symbol}"
+    cap = (
+        f"{_format_amount(vault.supply_cap, loan_decimals)} {loan_symbol}"
+        if vault.supply_cap > 0
+        else "0"
+    )
+    public = _format_public_status(vault, loan_decimals, loan_symbol, public_allocator)
+    name = vault.vault_symbol or vault.vault_name or "?"
+    return (name, vault.vault_address, alloc, cap, public)
+
+
+def _format_public_status(
+    vault: VaultAllocation,
+    loan_decimals: int,
+    loan_symbol: str,
+    public_allocator: str | None,
+) -> str:
+    role_granted = public_allocator is not None and any(
+        a.lower() == public_allocator.lower() for a in vault.allocators
+    )
+    if vault.flow_cap is None:
+        return "n/a (no flow cap configured)"
+    if not role_granted:
+        return "blocked (allocator role not granted to PublicAllocator)"
+    if vault.flow_cap.max_in == 0:
+        return "disabled (maxIn=0)"
+    fee_eth = vault.flow_cap.fee_wei / WAD
+    return (
+        f"in {_format_amount(vault.flow_cap.max_in, loan_decimals)} {loan_symbol}, "
+        f"fee {fee_eth:.6f} ETH"
+    )
+
+
+def _print_vault_allocators(
+    vault: VaultAllocation, public_allocator: str | None
+) -> None:
+    name = vault.vault_symbol or vault.vault_name or vault.vault_address
+    click.echo(f"Allocators for {name} ({vault.vault_address}):")
+    if not vault.allocators:
+        click.echo("  (none)")
+    else:
+        for addr in vault.allocators:
+            tag = ""
+            if public_allocator and addr.lower() == public_allocator.lower():
+                tag = "  [PublicAllocator — public reallocate enabled]"
+            elif (
+                vault.flow_cap
+                and vault.flow_cap.admin
+                and addr.lower() == vault.flow_cap.admin.lower()
+            ):
+                tag = "  [PublicAllocator admin]"
+            click.echo(f"  {addr}{tag}")
+    click.echo("")
+
+
+def _print_reallocate_hint(params: MorphoMarketParams) -> None:
+    click.echo(f"  loanToken:       {params.loan_token}")
+    click.echo(f"  collateralToken: {params.collateral_token}")
+    click.echo(f"  oracle:          {params.oracle}")
+    click.echo(f"  irm:             {params.irm}")
+    click.echo(f"  lltv:            {params.lltv}")
+
+
+def _build_json(
+    market_id: str,
+    chain_id: int,
+    params: MorphoMarketParams,
+    state: MorphoMarket,
+    rates: MorphoMarketRates,
+    api_market: MorphoApiMarket | None,
+    api_error: str | None,
+    public_allocator: str | None,
+) -> dict:
+    out: dict = {
+        "market_id": "0x" + market_id,
+        "chain_id": chain_id,
+        "public_allocator": public_allocator,
+        "market_params": {
+            "loan_token": params.loan_token,
+            "collateral_token": params.collateral_token,
+            "oracle": params.oracle,
+            "irm": params.irm,
+            "lltv": str(params.lltv),
+        },
+        "state": {
+            "total_supply_assets": str(state.total_supply_assets),
+            "total_supply_shares": str(state.total_supply_shares),
+            "total_borrow_assets": str(state.total_borrow_assets),
+            "total_borrow_shares": str(state.total_borrow_shares),
+            "liquidity_assets": str(
+                state.total_supply_assets - state.total_borrow_assets
+            ),
+            "fee_wad": str(state.fee),
+            "last_update": state.last_update,
+        },
+        "rates": {
+            "rate_per_second_wad": str(rates.rate_per_second_wad),
+            "utilization": rates.utilization,
+            "borrow_apy": rates.borrow_apy,
+            "supply_apy": rates.supply_apy,
+        },
+    }
+    if api_error:
+        out["api_error"] = api_error
+    if api_market is not None:
+        out["loan_asset"] = {
+            "address": api_market.loan_token,
+            "symbol": api_market.loan_symbol,
+            "decimals": api_market.loan_decimals,
+        }
+        out["collateral_asset"] = {
+            "address": api_market.collateral_token,
+            "symbol": api_market.collateral_symbol,
+            "decimals": api_market.collateral_decimals,
+        }
+        out["vaults"] = [_vault_to_json(v) for v in api_market.vaults]
+    return out
+
+
+def _vault_to_json(vault: VaultAllocation) -> dict:
+    entry: dict = {
+        "address": vault.vault_address,
+        "name": vault.vault_name,
+        "symbol": vault.vault_symbol,
+        "asset": {"symbol": vault.asset_symbol, "decimals": vault.asset_decimals},
+        "total_assets": str(vault.total_assets),
+        "supply_assets": str(vault.supply_assets),
+        "supply_cap": str(vault.supply_cap),
+        "allocators": list(vault.allocators),
+    }
+    if vault.flow_cap is not None:
+        entry["public_allocator_config"] = {
+            "fee_wei": str(vault.flow_cap.fee_wei),
+            "max_in": str(vault.flow_cap.max_in),
+            "max_out": str(vault.flow_cap.max_out),
+            "admin": vault.flow_cap.admin,
+        }
+    else:
+        entry["public_allocator_config"] = None
+    return entry
+
+
+# ───────────── meta-morpho subcommand ─────────────
+
+
+@market.command("meta-morpho")
+@click.argument("vault_address", type=ADDRESS)
+@click.option(
+    "--chain",
+    "chain_id",
+    type=CHAIN,
+    required=True,
+    help="Chain ID or name (ethereum, base, arbitrum, ...).",
+)
+@click.option(
+    "--market",
+    "market_filter",
+    type=str,
+    default=None,
+    help="Filter caps/allocations to a single Morpho Blue market ID.",
+)
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a table.",
+)
+def meta_morpho(
+    vault_address: str,
+    chain_id: int,
+    market_filter: str | None,
+    json_output: bool,
+) -> None:
+    """Inspect a MetaMorpho V1 or Morpho Vault V2 by address.
+
+    Auto-detects vault version. Shows roles (owner/curator/allocators/sentinels),
+    fees, adapters (V2) or supply allocations (V1), and per-market caps with
+    remaining headroom. Use --market to focus on a single Morpho Blue market —
+    useful when deciding whether to push liquidity into it via reallocate.
+    """
+    try:
+        info = fetch_vault(vault_address, chain_id)
+    except MorphoApiError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    market_filter_norm = (
+        ("0x" + market_filter.removeprefix("0x").lower()) if market_filter else None
+    )
+
+    if json_output:
+        click.echo(json_lib.dumps(_meta_morpho_json(info, chain_id), indent=2))
+        return
+
+    if isinstance(info, VaultV2Info):
+        _print_vault_v2(info, chain_id, market_filter_norm)
+    else:
+        _print_vault_v1(info, chain_id, market_filter_norm)
+
+
+def _print_vault_v2(
+    vault: VaultV2Info, chain_id: int, market_filter: str | None
+) -> None:
+    chain_name = CHAIN_NAMES.get(chain_id, str(chain_id))
+    click.secho(f"Morpho Vault V2 — {vault.name} ({vault.symbol})", bold=True)
+    click.echo(f"  Address:          {vault.address}")
+    click.echo(f"  Chain:            {chain_name} (id {chain_id})")
+    click.echo(
+        f"  Asset:            {vault.asset_symbol} "
+        f"({_format_amount(vault.total_assets, vault.asset_decimals)} total, "
+        f"{_format_amount(vault.idle_assets, vault.asset_decimals)} idle)"
+    )
+    click.echo(
+        f"  Liquidity:        {_format_amount(vault.liquidity, vault.asset_decimals)} {vault.asset_symbol}"
+    )
+    click.echo(f"  Share price:      {vault.share_price:.6f}")
+    click.echo(f"  Max APY:          {vault.max_apy * 100:.2f}%")
+    click.echo("")
+    click.echo("Roles:")
+    click.echo(f"  Owner:            {vault.owner}")
+    click.echo(f"  Curator:          {vault.curator}")
+    click.echo(
+        f"  Performance fee:  {vault.performance_fee * 100:.2f}% → {vault.performance_fee_recipient}"
+    )
+    click.echo(
+        f"  Management fee:   {vault.management_fee * 100:.2f}% → {vault.management_fee_recipient}"
+    )
+    click.echo(f"  Allocators ({len(vault.allocators)}):")
+    for addr in vault.allocators or ["(none)"]:
+        click.echo(f"    {addr}")
+    click.echo(f"  Sentinels ({len(vault.sentinels)}):")
+    for addr in vault.sentinels or ["(none)"]:
+        click.echo(f"    {addr}")
+    click.echo("")
+    click.echo("Adapters:")
+    if not vault.adapters:
+        click.echo("  (none)")
+    else:
+        adapter_rows: list[tuple[str, ...]] = [
+            (
+                a.adapter_type or "?",
+                a.address,
+                _format_amount(a.assets, vault.asset_decimals)
+                + " "
+                + vault.asset_symbol,
+                a.inner_vault or "",
+            )
+            for a in vault.adapters
+        ]
+        _print_table(("Type", "Adapter", "Assets", "Inner vault"), adapter_rows)
+    if vault.liquidity_adapter:
+        click.echo("")
+        click.echo(f"  Liquidity adapter: {vault.liquidity_adapter.address}")
+    click.echo("")
+
+    market_caps = [c for c in vault.caps if c.cap_type == "MarketV1"]
+    other_caps = [c for c in vault.caps if c.cap_type != "MarketV1"]
+    if market_filter:
+        market_caps = [
+            c for c in market_caps if (c.market_id or "").lower() == market_filter
+        ]
+
+    click.secho(f"Morpho Blue market caps ({len(market_caps)}):", bold=True)
+    _print_market_caps(market_caps, vault.asset_symbol, vault.asset_decimals)
+    click.echo("")
+    if not market_filter:
+        click.secho(f"Other caps ({len(other_caps)}):", bold=True)
+        _print_other_caps(other_caps, vault.asset_symbol, vault.asset_decimals)
+
+
+def _print_market_caps(
+    caps: list[VaultV2Cap], asset_symbol: str, asset_decimals: int
+) -> None:
+    if not caps:
+        click.echo("  (none)")
+        return
+    rows: list[tuple[str, ...]] = []
+    for cap in caps:
+        market_short = (cap.market_id or "?")[:18] + "…"
+        rows.append(
+            (
+                market_short,
+                _format_amount(cap.absolute_cap, asset_decimals),
+                _format_amount(cap.allocation, asset_decimals),
+                _format_amount(cap.room, asset_decimals),
+                f"LLTV {cap.lltv / WAD * 100:.0f}%" if cap.lltv else "",
+            )
+        )
+    _print_table(
+        ("Market (short)", f"Cap ({asset_symbol})", "Allocated", "Room", "LLTV"),
+        rows,
+    )
+    click.echo("")
+    for cap in caps:
+        if not cap.market_id:
+            continue
+        click.echo(f"Market {cap.market_id}")
+        click.echo(f"  loanToken:       {cap.loan_token}")
+        click.echo(f"  collateralToken: {cap.collateral_token}")
+        click.echo(f"  oracle:          {cap.oracle}")
+        click.echo(f"  irm:             {cap.irm}")
+        click.echo(f"  lltv:            {cap.lltv}")
+        click.echo(
+            f"  cap / alloc / room: "
+            f"{_format_amount(cap.absolute_cap, asset_decimals)} / "
+            f"{_format_amount(cap.allocation, asset_decimals)} / "
+            f"{_format_amount(cap.room, asset_decimals)} {asset_symbol}"
+        )
+
+
+def _print_other_caps(
+    caps: list[VaultV2Cap], asset_symbol: str, asset_decimals: int
+) -> None:
+    if not caps:
+        click.echo("  (none)")
+        return
+    rows: list[tuple[str, ...]] = [
+        (
+            c.cap_type,
+            c.cap_id[:18] + "…",
+            _format_amount(c.absolute_cap, asset_decimals),
+            _format_amount(c.allocation, asset_decimals),
+            _format_amount(c.room, asset_decimals),
+        )
+        for c in caps
+    ]
+    _print_table(
+        ("Type", "Cap ID", f"Cap ({asset_symbol})", "Allocated", "Room"),
+        rows,
+    )
+
+
+def _print_vault_v1(
+    vault: VaultV1Info, chain_id: int, market_filter: str | None
+) -> None:
+    chain_name = CHAIN_NAMES.get(chain_id, str(chain_id))
+    public_allocator = PUBLIC_ALLOCATOR_ADDRESSES.get(chain_id)
+    role_granted = public_allocator is not None and any(
+        a.lower() == public_allocator.lower() for a in vault.allocators
+    )
+    click.secho(f"MetaMorpho V1 — {vault.name} ({vault.symbol})", bold=True)
+    click.echo(f"  Address:          {vault.address}")
+    click.echo(f"  Chain:            {chain_name} (id {chain_id})")
+    click.echo(
+        f"  Asset:            {vault.asset_symbol} "
+        f"({_format_amount(vault.total_assets, vault.asset_decimals)} total)"
+    )
+    click.echo(
+        f"  Performance fee:  {vault.fee_wad / WAD * 100:.2f}% → {vault.fee_recipient}"
+    )
+    click.echo("")
+    click.echo("Roles:")
+    click.echo(f"  Owner:            {vault.owner}")
+    click.echo(f"  Curator:          {vault.curator}")
+    click.echo(f"  Guardian:         {vault.guardian}")
+    click.echo(f"  Allocators ({len(vault.allocators)}):")
+    for addr in vault.allocators or ["(none)"]:
+        tag = (
+            "  [PublicAllocator]"
+            if public_allocator and addr.lower() == public_allocator.lower()
+            else ""
+        )
+        click.echo(f"    {addr}{tag}")
+    click.echo("")
+    click.echo("Public reallocate:")
+    if not vault.public_allocator:
+        click.echo("  (no PublicAllocator config)")
+    else:
+        fee_eth = vault.public_allocator.fee_wei / WAD
+        status = "enabled" if role_granted else "blocked (role not granted)"
+        click.echo(f"  Status:           {status}")
+        click.echo(f"  Fee:              {fee_eth:.6f} ETH per call")
+        click.echo(f"  Admin:            {vault.public_allocator.admin}")
+    click.echo("")
+
+    allocations = vault.allocations
+    if market_filter:
+        allocations = [a for a in allocations if a.market_id.lower() == market_filter]
+    click.secho(f"Allocations ({len(allocations)}):", bold=True)
+    if not allocations:
+        click.echo("  (none)")
+        return
+    rows: list[tuple[str, ...]] = []
+    for alloc in allocations:
+        flow = vault.public_allocator_flow_caps.get(alloc.market_id.lower(), (0, 0))
+        flow_str = (
+            f"in {_format_amount(flow[0], alloc.loan_decimals)}" if flow[0] else "—"
+        )
+        rows.append(
+            (
+                alloc.market_id[:18] + "…",
+                f"{alloc.loan_symbol}/{alloc.collateral_symbol}",
+                _format_amount(alloc.supply_assets, alloc.loan_decimals),
+                _format_amount(alloc.supply_cap, alloc.loan_decimals),
+                _format_amount(alloc.cap_room, alloc.loan_decimals),
+                flow_str,
+            )
+        )
+    _print_table(
+        ("Market", "Pair", "Allocated", "Cap", "Room", "Public flow in"),
+        rows,
+    )
+
+
+def _meta_morpho_json(info: VaultV1Info | VaultV2Info, chain_id: int) -> dict:
+    if isinstance(info, VaultV2Info):
+        return {
+            "version": "v2",
+            "chain_id": chain_id,
+            "address": info.address,
+            "name": info.name,
+            "symbol": info.symbol,
+            "asset": {
+                "address": info.asset_address,
+                "symbol": info.asset_symbol,
+                "decimals": info.asset_decimals,
+            },
+            "total_assets": str(info.total_assets),
+            "idle_assets": str(info.idle_assets),
+            "liquidity": str(info.liquidity),
+            "share_price": info.share_price,
+            "max_apy": info.max_apy,
+            "performance_fee": info.performance_fee,
+            "performance_fee_recipient": info.performance_fee_recipient,
+            "management_fee": info.management_fee,
+            "management_fee_recipient": info.management_fee_recipient,
+            "owner": info.owner,
+            "curator": info.curator,
+            "allocators": list(info.allocators),
+            "sentinels": list(info.sentinels),
+            "liquidity_adapter": (
+                {
+                    "address": info.liquidity_adapter.address,
+                    "type": info.liquidity_adapter.adapter_type,
+                    "assets": str(info.liquidity_adapter.assets),
+                    "inner_vault": info.liquidity_adapter.inner_vault,
+                }
+                if info.liquidity_adapter
+                else None
+            ),
+            "adapters": [
+                {
+                    "address": a.address,
+                    "type": a.adapter_type,
+                    "assets": str(a.assets),
+                    "inner_vault": a.inner_vault,
+                }
+                for a in info.adapters
+            ],
+            "caps": [_v2_cap_json(c) for c in info.caps],
+        }
+    return {
+        "version": "v1",
+        "chain_id": chain_id,
+        "address": info.address,
+        "name": info.name,
+        "symbol": info.symbol,
+        "asset": {
+            "address": info.asset_address,
+            "symbol": info.asset_symbol,
+            "decimals": info.asset_decimals,
+        },
+        "total_assets": str(info.total_assets),
+        "fee_wad": str(info.fee_wad),
+        "owner": info.owner,
+        "curator": info.curator,
+        "guardian": info.guardian,
+        "fee_recipient": info.fee_recipient,
+        "allocators": list(info.allocators),
+        "public_allocator": (
+            {
+                "fee_wei": str(info.public_allocator.fee_wei),
+                "admin": info.public_allocator.admin,
+                "flow_caps": {
+                    mid: {"max_in": str(mi), "max_out": str(mo)}
+                    for mid, (mi, mo) in info.public_allocator_flow_caps.items()
+                },
+            }
+            if info.public_allocator
+            else None
+        ),
+        "allocations": [
+            {
+                "market_id": a.market_id,
+                "lltv": str(a.lltv),
+                "loan_symbol": a.loan_symbol,
+                "loan_decimals": a.loan_decimals,
+                "collateral_symbol": a.collateral_symbol,
+                "supply_assets": str(a.supply_assets),
+                "supply_cap": str(a.supply_cap),
+                "cap_room": str(a.cap_room),
+                "market_supply_apy": a.market_supply_apy,
+            }
+            for a in info.allocations
+        ],
+    }
+
+
+def _v2_cap_json(cap: VaultV2Cap) -> dict:
+    return {
+        "cap_id": cap.cap_id,
+        "type": cap.cap_type,
+        "id_data": cap.id_data,
+        "absolute_cap": str(cap.absolute_cap),
+        "relative_cap_wad": str(cap.relative_cap_wad),
+        "allocation": str(cap.allocation),
+        "room": str(cap.room),
+        "market_id": cap.market_id,
+        "loan_token": cap.loan_token,
+        "collateral_token": cap.collateral_token,
+        "oracle": cap.oracle,
+        "irm": cap.irm,
+        "lltv": str(cap.lltv) if cap.lltv is not None else None,
+    }

--- a/src/ipor_fusion/cli/morpho_api.py
+++ b/src/ipor_fusion/cli/morpho_api.py
@@ -1,0 +1,674 @@
+"""Minimal client for the Morpho public GraphQL API (`blue-api.morpho.org`).
+
+Used by `fusion market morpho-blue` to discover MetaMorpho vaults supplying a
+market and their `PublicAllocator` flow caps, and by `fusion market meta-morpho`
+to inspect a vault's roles, caps, and allocations. Supports both MetaMorpho V1
+(`vaultByAddress`) and Morpho Vault V2 (`vaultV2ByAddress`). Stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from eth_abi import decode, encode
+from eth_utils import keccak
+from web3 import Web3
+
+MORPHO_API_URL = "https://blue-api.morpho.org/graphql"
+
+# Singleton PublicAllocator deployments per chain. Updated 2026-04 from the
+# Morpho API (`publicAllocators` query). Anyone can call `reallocateTo` on
+# this contract — the vault must have granted it the ALLOCATOR_ROLE for
+# public reallocation to actually go through.
+PUBLIC_ALLOCATOR_ADDRESSES: dict[int, str] = {
+    1: "0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D",  # Ethereum
+    10: "0x0d68a97324E602E02799CD83B42D337207B40658",  # OP Mainnet
+    137: "0xfac15aff53ADd2ff80C2962127C434E8615Df0d3",  # Polygon
+    8453: "0xA090dD1a701408Df1d4d0B85b716c87565f90467",  # Base
+    42161: "0x769583Af5e9D03589F159EbEC31Cc2c23E8C355E",  # Arbitrum One
+    130: "0xB0c9a107fA17c779B3378210A7a593e88938C7C9",  # Unichain
+    480: "0xef9889B4e443DEd35FA0Bd060f2104Cca94e6A43",  # World Chain
+    143: "0xfd70575B732F9482F4197FE1075492e114E97302",  # Monad
+    999: "0x517505be22D9068687334e69ae7a02fC77edf4Fc",  # HyperEVM
+    988: "0xbCB063D4B6D479b209C186e462828CBACaC82DbE",  # Stable
+    747474: "0x39EB6Da5e88194C82B13491Df2e8B3E213eD2412",  # Katana
+}
+
+_MARKET_QUERY = """
+query MarketWithVaults($marketId: String!, $chainId: Int!) {
+  marketById(marketId: $marketId, chainId: $chainId) {
+    marketId
+    lltv
+    loanAsset { address symbol decimals }
+    collateralAsset { address symbol decimals }
+    oracle { address }
+    irmAddress
+    state {
+      supplyAssets
+      borrowAssets
+      liquidityAssets
+      utilization
+      supplyApy
+      borrowApy
+      fee
+      timestamp
+    }
+    supplyingVaults {
+      address
+      symbol
+      name
+      asset { symbol decimals }
+      state {
+        totalAssets
+        allocation { market { marketId } supplyAssets supplyCap }
+      }
+      allocators { address }
+      publicAllocatorConfig {
+        fee
+        admin
+        flowCaps {
+          market { marketId }
+          maxIn
+          maxOut
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@dataclass(slots=True)
+class VaultFlowCap:
+    """PublicAllocator flow caps for a (vault, market) pair."""
+
+    fee_wei: int
+    max_in: int
+    max_out: int
+    admin: str | None  # the address that can configure these flow caps
+
+
+@dataclass(slots=True)
+class VaultAllocation:
+    """A MetaMorpho vault's exposure to a single Morpho Blue market."""
+
+    vault_address: str
+    vault_name: str
+    vault_symbol: str
+    asset_symbol: str
+    asset_decimals: int
+    total_assets: int
+    supply_assets: int  # currently allocated to *this* market
+    supply_cap: int  # cap configured by curator for *this* market
+    allocators: list[str]  # addresses with ALLOCATOR_ROLE on the vault
+    flow_cap: VaultFlowCap | None  # None if PublicAllocator not configured
+
+
+@dataclass(slots=True)
+# pylint: disable-next=too-many-instance-attributes
+class MorphoApiMarket:
+    """Snapshot of a Morpho Blue market plus the vaults supplying to it."""
+
+    market_id: str
+    lltv: int
+    loan_token: str
+    loan_symbol: str
+    loan_decimals: int
+    collateral_token: str
+    collateral_symbol: str
+    collateral_decimals: int
+    oracle: str
+    irm: str
+    supply_assets: int
+    borrow_assets: int
+    liquidity_assets: int
+    utilization: float
+    supply_apy: float
+    borrow_apy: float
+    fee_wad: int
+    timestamp: int
+    vaults: list[VaultAllocation]
+
+
+class MorphoApiError(RuntimeError):
+    """Raised when the Morpho API returns an error or is unreachable."""
+
+
+def fetch_market(
+    market_id: str, chain_id: int, *, timeout: float = 10.0
+) -> MorphoApiMarket:
+    """Fetch a Morpho Blue market with its supplying vaults from the public API.
+
+    `market_id` is the 0x-prefixed market unique key. `chain_id` is the EVM chain
+    ID (1 = mainnet, 8453 = base, ...). Raises `MorphoApiError` on network failure
+    or if the market is not indexed.
+    """
+    if not market_id.startswith("0x"):
+        market_id = "0x" + market_id
+    payload = json.dumps(
+        {
+            "query": _MARKET_QUERY,
+            "variables": {"marketId": market_id, "chainId": chain_id},
+        }
+    ).encode()
+    req = Request(
+        MORPHO_API_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed URL
+            body = json.loads(resp.read())
+    except (URLError, TimeoutError) as exc:
+        raise MorphoApiError(f"Morpho API unreachable: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise MorphoApiError(f"Morpho API returned invalid JSON: {exc}") from exc
+
+    if errors := body.get("errors"):
+        raise MorphoApiError(f"Morpho API error: {errors}")
+    market = (body.get("data") or {}).get("marketById")
+    if not market:
+        raise MorphoApiError(
+            f"Market {market_id} not found on chain {chain_id} in Morpho index."
+        )
+    return _parse_market(market)
+
+
+def _parse_market(raw: dict) -> MorphoApiMarket:
+    state = raw.get("state") or {}
+    return MorphoApiMarket(
+        market_id=raw["marketId"],
+        lltv=int(raw["lltv"]),
+        loan_token=raw["loanAsset"]["address"],
+        loan_symbol=raw["loanAsset"]["symbol"],
+        loan_decimals=int(raw["loanAsset"]["decimals"]),
+        collateral_token=raw["collateralAsset"]["address"],
+        collateral_symbol=raw["collateralAsset"]["symbol"],
+        collateral_decimals=int(raw["collateralAsset"]["decimals"]),
+        oracle=raw["oracle"]["address"],
+        irm=raw["irmAddress"],
+        supply_assets=int(state.get("supplyAssets") or 0),
+        borrow_assets=int(state.get("borrowAssets") or 0),
+        liquidity_assets=int(state.get("liquidityAssets") or 0),
+        utilization=float(state.get("utilization") or 0.0),
+        supply_apy=float(state.get("supplyApy") or 0.0),
+        borrow_apy=float(state.get("borrowApy") or 0.0),
+        fee_wad=int(state.get("fee") or 0),
+        timestamp=int(state.get("timestamp") or 0),
+        vaults=[
+            _parse_vault(v, raw["marketId"]) for v in raw.get("supplyingVaults") or []
+        ],
+    )
+
+
+_VAULT_V2_QUERY = """
+query VaultV2($address: String!, $chainId: Int!) {
+  vaultV2ByAddress(address: $address, chainId: $chainId) {
+    address name symbol
+    asset { address symbol decimals }
+    totalAssets idleAssets liquidity sharePrice
+    performanceFee performanceFeeRecipient
+    managementFee managementFeeRecipient
+    maxApy
+    owner { address }
+    curator { address }
+    allocators { allocator { address } }
+    sentinels { sentinel { address } }
+    liquidityAdapter {
+      __typename
+      ... on MorphoMarketV1Adapter { address type assets }
+      ... on MetaMorphoAdapter { address type assets metaMorpho { address symbol } }
+    }
+    adapters {
+      items {
+        __typename
+        ... on MorphoMarketV1Adapter { address type assets }
+        ... on MetaMorphoAdapter { address type assets metaMorpho { address symbol } }
+      }
+    }
+    caps {
+      items { id idData type absoluteCap relativeCap allocation }
+    }
+  }
+}
+"""
+
+_VAULT_V1_QUERY = """
+query VaultV1($address: String!, $chainId: Int!) {
+  vaultByAddress(address: $address, chainId: $chainId) {
+    address name symbol
+    asset { address symbol decimals }
+    state {
+      totalAssets fee owner curator guardian feeRecipient
+      allocation {
+        market {
+          marketId lltv
+          loanAsset { symbol decimals }
+          collateralAsset { symbol }
+          state { supplyAssets borrowAssets supplyApy }
+        }
+        supplyAssets supplyCap
+      }
+    }
+    allocators { address }
+    publicAllocatorConfig {
+      fee admin
+      flowCaps { market { marketId } maxIn maxOut }
+    }
+  }
+}
+"""
+
+
+@dataclass(slots=True)
+class VaultV2Cap:
+    """A single cap entry on a Morpho Vault V2.
+
+    `cap_id` is the bytes32 cap key (keccak256 of `id_data`). `cap_type` is one
+    of `MarketV1` (Morpho Blue market), `Adapter` (per-adapter cap),
+    `Collateral` (cap by collateral token across markets), or `Unknown`.
+    For `MarketV1`, `market_id`/`loan_token`/`collateral_token`/`oracle`/`irm`/
+    `lltv` are decoded from `id_data`; for other types they are `None`.
+    """
+
+    cap_id: str
+    cap_type: str
+    id_data: str
+    absolute_cap: int
+    relative_cap_wad: int
+    allocation: int
+    market_id: str | None
+    loan_token: str | None
+    collateral_token: str | None
+    oracle: str | None
+    irm: str | None
+    lltv: int | None
+
+    @property
+    def room(self) -> int:
+        """Free space below the absolute cap (clamped at 0)."""
+        return max(self.absolute_cap - self.allocation, 0)
+
+
+@dataclass(slots=True)
+class VaultV2Adapter:
+    """An adapter contract attached to a Vault V2 (e.g. Morpho adapter)."""
+
+    address: str
+    adapter_type: str
+    assets: int
+    inner_vault: str | None  # for MorphoVaultV2Adapter: the underlying market vault
+
+
+@dataclass(slots=True)
+# pylint: disable-next=too-many-instance-attributes
+class VaultV2Info:
+    """Snapshot of a Morpho Vault V2."""
+
+    address: str
+    name: str
+    symbol: str
+    asset_address: str
+    asset_symbol: str
+    asset_decimals: int
+    total_assets: int
+    idle_assets: int
+    liquidity: int
+    share_price: float
+    max_apy: float
+    performance_fee: float
+    performance_fee_recipient: str
+    management_fee: float
+    management_fee_recipient: str
+    owner: str
+    curator: str
+    allocators: list[str]
+    sentinels: list[str]
+    liquidity_adapter: VaultV2Adapter | None
+    adapters: list[VaultV2Adapter]
+    caps: list[VaultV2Cap] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class VaultV1MarketAllocation:
+    """A MetaMorpho V1 allocation entry."""
+
+    market_id: str
+    lltv: int
+    loan_symbol: str
+    loan_decimals: int
+    collateral_symbol: str
+    market_supply_assets: int
+    market_borrow_assets: int
+    market_supply_apy: float
+    supply_assets: int
+    supply_cap: int
+
+    @property
+    def cap_room(self) -> int:
+        return max(self.supply_cap - self.supply_assets, 0)
+
+
+@dataclass(slots=True)
+# pylint: disable-next=too-many-instance-attributes
+class VaultV1Info:
+    """Snapshot of a MetaMorpho V1 vault."""
+
+    address: str
+    name: str
+    symbol: str
+    asset_address: str
+    asset_symbol: str
+    asset_decimals: int
+    total_assets: int
+    fee_wad: int
+    owner: str
+    curator: str
+    guardian: str
+    fee_recipient: str
+    allocators: list[str]
+    allocations: list[VaultV1MarketAllocation]
+    public_allocator: VaultFlowCap | None  # vault-level (no flowCap filtering)
+    public_allocator_flow_caps: dict[str, tuple[int, int]]  # marketId -> (maxIn,maxOut)
+
+
+def fetch_vault(
+    address: str, chain_id: int, *, timeout: float = 10.0
+) -> VaultV2Info | VaultV1Info:
+    """Fetch a Morpho vault by address. Tries V2 first, falls back to V1.
+
+    Raises `MorphoApiError` if the address is not a Morpho vault on this chain.
+    """
+    address = Web3.to_checksum_address(address)
+    v2_body = _post_query(
+        _VAULT_V2_QUERY, {"address": address, "chainId": chain_id}, timeout
+    )
+    v2 = (v2_body.get("data") or {}).get("vaultV2ByAddress") if v2_body else None
+    if v2:
+        return _parse_vault_v2(v2)
+    v1_body = _post_query(
+        _VAULT_V1_QUERY, {"address": address, "chainId": chain_id}, timeout
+    )
+    v1 = (v1_body.get("data") or {}).get("vaultByAddress") if v1_body else None
+    if v1:
+        return _parse_vault_v1(v1)
+    raise MorphoApiError(
+        f"Vault {address} not found on chain {chain_id} (neither V1 nor V2)."
+    )
+
+
+def _post_query(query: str, variables: dict, timeout: float) -> dict:
+    """POST a GraphQL query and return the parsed body. Tolerates NOT_FOUND."""
+    payload = json.dumps({"query": query, "variables": variables}).encode()
+    req = Request(
+        MORPHO_API_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed URL
+            body = json.loads(resp.read())
+    except (URLError, TimeoutError) as exc:
+        raise MorphoApiError(f"Morpho API unreachable: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise MorphoApiError(f"Morpho API returned invalid JSON: {exc}") from exc
+    # NOT_FOUND errors come back with errors[].status == "NOT_FOUND" and data: null.
+    # We swallow those (caller decides) and re-raise other GraphQL errors.
+    if errors := body.get("errors"):
+        statuses = {e.get("status") for e in errors}
+        if statuses - {"NOT_FOUND"}:
+            raise MorphoApiError(f"Morpho API error: {errors}")
+    return body
+
+
+def _parse_vault_v2(raw: dict) -> VaultV2Info:
+    asset = raw.get("asset") or {}
+    liq_adapter = raw.get("liquidityAdapter") or {}
+    adapters = [
+        _parse_v2_adapter(a) for a in (raw.get("adapters") or {}).get("items", []) if a
+    ]
+    caps = [_parse_v2_cap(c) for c in (raw.get("caps") or {}).get("items", []) if c]
+    return VaultV2Info(
+        address=raw["address"],
+        name=raw.get("name") or "",
+        symbol=raw.get("symbol") or "",
+        asset_address=asset.get("address") or "",
+        asset_symbol=asset.get("symbol") or "",
+        asset_decimals=int(asset.get("decimals") or 0),
+        total_assets=int(raw.get("totalAssets") or 0),
+        idle_assets=int(raw.get("idleAssets") or 0),
+        liquidity=int(raw.get("liquidity") or 0),
+        share_price=float(raw.get("sharePrice") or 0.0),
+        max_apy=float(raw.get("maxApy") or 0.0),
+        performance_fee=float(raw.get("performanceFee") or 0.0),
+        performance_fee_recipient=raw.get("performanceFeeRecipient") or "",
+        management_fee=float(raw.get("managementFee") or 0.0),
+        management_fee_recipient=raw.get("managementFeeRecipient") or "",
+        owner=(raw.get("owner") or {}).get("address") or "",
+        curator=(raw.get("curator") or {}).get("address") or "",
+        allocators=[
+            a["allocator"]["address"]
+            for a in raw.get("allocators") or []
+            if (a.get("allocator") or {}).get("address")
+        ],
+        sentinels=[
+            s["sentinel"]["address"]
+            for s in raw.get("sentinels") or []
+            if (s.get("sentinel") or {}).get("address")
+        ],
+        liquidity_adapter=_parse_v2_adapter(liq_adapter) if liq_adapter else None,
+        adapters=adapters,
+        caps=caps,
+    )
+
+
+def _parse_v2_adapter(raw: dict) -> VaultV2Adapter:
+    return VaultV2Adapter(
+        address=raw.get("address") or "",
+        adapter_type=raw.get("type") or raw.get("__typename") or "",
+        assets=int(raw.get("assets") or 0),
+        inner_vault=(raw.get("metaMorpho") or {}).get("address"),
+    )
+
+
+def _parse_v2_cap(raw: dict) -> VaultV2Cap:
+    cap_type = raw.get("type") or "Unknown"
+    id_data = raw.get("idData") or "0x"
+    market_id, loan, collat, oracle, irm, lltv = (None, None, None, None, None, None)
+    if cap_type == "MarketV1":
+        decoded = _decode_market_v1_id_data(id_data)
+        if decoded:
+            loan, collat, oracle, irm, lltv = decoded
+            market_id = _morpho_blue_market_id(loan, collat, oracle, irm, lltv)
+    return VaultV2Cap(
+        cap_id=raw.get("id") or "",
+        cap_type=cap_type,
+        id_data=id_data,
+        absolute_cap=int(raw.get("absoluteCap") or 0),
+        relative_cap_wad=int(raw.get("relativeCap") or 0),
+        allocation=int(raw.get("allocation") or 0),
+        market_id=market_id,
+        loan_token=loan,
+        collateral_token=collat,
+        oracle=oracle,
+        irm=irm,
+        lltv=lltv,
+    )
+
+
+def _decode_market_v1_id_data(
+    id_data: str,
+) -> tuple[str, str, str, str, int] | None:
+    """Decode a Vault V2 `MarketV1`-type cap idData into MarketParams.
+
+    Vault V2 encodes the cap idData as `abi.encode(string idType, address adapter,
+    address loan, address collateral, address oracle, address irm, uint256 lltv)`,
+    where `idType` is the literal string `"this/marketParams"`. Returns
+    `(loan, collateral, oracle, irm, lltv)` on success, or `None` if the payload
+    does not match.
+    """
+    raw = id_data.removeprefix("0x")
+    try:
+        data = bytes.fromhex(raw)
+        decoded_list = list(
+            decode(
+                [
+                    "string",
+                    "address",
+                    "address",
+                    "address",
+                    "address",
+                    "address",
+                    "uint256",
+                ],
+                data,
+            )
+        )
+    except Exception:  # pylint: disable=broad-except
+        # eth_abi raises various subclasses (DecodingError, InsufficientDataBytes, ...)
+        # for malformed payloads — treat them all as "not a MarketV1 cap".
+        return None
+    if len(decoded_list) != 7 or decoded_list[0] != "this/marketParams":
+        return None
+    loan, collat, oracle, irm, lltv = (
+        decoded_list[2],
+        decoded_list[3],
+        decoded_list[4],
+        decoded_list[5],
+        decoded_list[6],
+    )
+    return (
+        Web3.to_checksum_address(loan),
+        Web3.to_checksum_address(collat),
+        Web3.to_checksum_address(oracle),
+        Web3.to_checksum_address(irm),
+        int(lltv),
+    )
+
+
+def _morpho_blue_market_id(
+    loan: str, collateral: str, oracle: str, irm: str, lltv: int
+) -> str:
+    """Compute a Morpho Blue market unique key from MarketParams.
+
+    `marketId = keccak256(abi.encode(loanToken, collateralToken, oracle, irm, lltv))`
+    — used by Morpho Blue's `idToMarketParams` mapping.
+    """
+    encoded = encode(
+        ["address", "address", "address", "address", "uint256"],
+        [loan, collateral, oracle, irm, lltv],
+    )
+    return "0x" + keccak(encoded).hex()
+
+
+def _parse_vault_v1(raw: dict) -> VaultV1Info:
+    asset = raw.get("asset") or {}
+    state = raw.get("state") or {}
+    allocations = []
+    for entry in state.get("allocation") or []:
+        market = entry.get("market") or {}
+        m_state = market.get("state") or {}
+        loan_asset = market.get("loanAsset") or {}
+        collat_asset = market.get("collateralAsset") or {}
+        allocations.append(
+            VaultV1MarketAllocation(
+                market_id=market.get("marketId") or "",
+                lltv=int(market.get("lltv") or 0),
+                loan_symbol=loan_asset.get("symbol") or "",
+                loan_decimals=int(loan_asset.get("decimals") or 0),
+                collateral_symbol=collat_asset.get("symbol") or "",
+                market_supply_assets=int(m_state.get("supplyAssets") or 0),
+                market_borrow_assets=int(m_state.get("borrowAssets") or 0),
+                market_supply_apy=float(m_state.get("supplyApy") or 0.0),
+                supply_assets=int(entry.get("supplyAssets") or 0),
+                supply_cap=int(entry.get("supplyCap") or 0),
+            )
+        )
+
+    pac = raw.get("publicAllocatorConfig")
+    flow_cap_summary: VaultFlowCap | None = None
+    flow_caps: dict[str, tuple[int, int]] = {}
+    if pac:
+        flow_cap_summary = VaultFlowCap(
+            fee_wei=int(pac.get("fee") or 0),
+            max_in=0,
+            max_out=0,
+            admin=pac.get("admin"),
+        )
+        for fc in pac.get("flowCaps") or []:
+            mid = ((fc.get("market") or {}).get("marketId") or "").lower()
+            if mid:
+                flow_caps[mid] = (int(fc.get("maxIn") or 0), int(fc.get("maxOut") or 0))
+
+    return VaultV1Info(
+        address=raw["address"],
+        name=raw.get("name") or "",
+        symbol=raw.get("symbol") or "",
+        asset_address=asset.get("address") or "",
+        asset_symbol=asset.get("symbol") or "",
+        asset_decimals=int(asset.get("decimals") or 0),
+        total_assets=int(state.get("totalAssets") or 0),
+        fee_wad=int(state.get("fee") or 0),
+        owner=state.get("owner") or "",
+        curator=state.get("curator") or "",
+        guardian=state.get("guardian") or "",
+        fee_recipient=state.get("feeRecipient") or "",
+        allocators=[
+            a["address"] for a in raw.get("allocators") or [] if a.get("address")
+        ],
+        allocations=allocations,
+        public_allocator=flow_cap_summary,
+        public_allocator_flow_caps=flow_caps,
+    )
+
+
+def _parse_vault(raw: dict, market_id: str) -> VaultAllocation:
+    asset = raw.get("asset") or {}
+    state = raw.get("state") or {}
+    allocation_for_market: dict = next(
+        (
+            a
+            for a in (state.get("allocation") or [])
+            if (a.get("market") or {}).get("marketId", "").lower() == market_id.lower()
+        ),
+        {},
+    )
+    pac = raw.get("publicAllocatorConfig")
+    flow_cap: VaultFlowCap | None = None
+    if pac:
+        flow_for_market = next(
+            (
+                fc
+                for fc in (pac.get("flowCaps") or [])
+                if (fc.get("market") or {}).get("marketId", "").lower()
+                == market_id.lower()
+            ),
+            None,
+        )
+        if flow_for_market:
+            flow_cap = VaultFlowCap(
+                fee_wei=int(pac.get("fee") or 0),
+                max_in=int(flow_for_market.get("maxIn") or 0),
+                max_out=int(flow_for_market.get("maxOut") or 0),
+                admin=pac.get("admin"),
+            )
+    allocators = [
+        a["address"] for a in (raw.get("allocators") or []) if a.get("address")
+    ]
+    return VaultAllocation(
+        vault_address=raw["address"],
+        vault_name=raw.get("name") or "",
+        vault_symbol=raw.get("symbol") or "",
+        asset_symbol=asset.get("symbol") or "",
+        asset_decimals=int(asset.get("decimals") or 0),
+        total_assets=int(state.get("totalAssets") or 0),
+        supply_assets=int(allocation_for_market.get("supplyAssets") or 0),
+        supply_cap=int(allocation_for_market.get("supplyCap") or 0),
+        allocators=allocators,
+        flow_cap=flow_cap,
+    )

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -451,9 +451,11 @@ def _print_vault_info(
     api_key = cfg.etherscan_api_key
     chain_label = CHAIN_NAMES.get(chain_id, str(chain_id))
 
-    data.deployment_block, data.deployment_timestamp = _fetch_deployment_info(
-        ctx, chain_id, vault_address, api_key
-    )
+    (
+        data.deployment_block,
+        data.deployment_timestamp,
+        data.deployment_error,
+    ) = _fetch_deployment_info(ctx, chain_id, vault_address, api_key)
 
     if json_output:
         result = _build_json_output(
@@ -483,6 +485,8 @@ def _print_vault_info(
         click.echo(
             f"Deployed at:      block {data.deployment_block}" f" ({deploy_iso}, {age})"
         )
+    elif data.deployment_error:
+        click.echo(f"Deployed at:      N/A ({data.deployment_error})")
     else:
         click.echo("Deployed at:      N/A")
     click.echo(f"Asset:            {data.asset} ({data.asset_symbol})")
@@ -618,6 +622,8 @@ def _build_share_price_json(data: _VaultData) -> dict | None:
 
 def _build_deployment_json(data: _VaultData) -> dict | None:
     if data.deployment_block is None or data.deployment_timestamp is None:
+        if data.deployment_error:
+            return {"error": data.deployment_error}
         return None
     return {
         "block": data.deployment_block,

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -42,6 +42,7 @@ from ipor_fusion.cli.vault_rendering import (
     _substrate_details,
 )
 from ipor_fusion.cli.vault_substrate import (
+    _format_market_label,
     _format_substrate,
     _market_name,
 )
@@ -541,8 +542,24 @@ def _print_vault_info(
         _print_pending_requests(data, plasma_vault)
     click.echo()
 
-    click.echo(f"Fuses ({len(data.fuses)}):")
-    _print_fuses_table(data.fuses, chain_id, api_key)
+    _print_fuse_section(
+        "Fuses",
+        data.fuses,
+        data.fuse_markets,
+        data.market_substrates,
+        chain_id,
+        api_key,
+    )
+    click.echo()
+
+    _print_fuse_section(
+        "Instant Withdrawal Fuses",
+        data.instant_fuses,
+        data.fuse_markets,
+        data.market_substrates,
+        chain_id,
+        api_key,
+    )
     click.echo()
 
     click.echo(f"Balance Fuses ({len(data.balance_fuses)}):")
@@ -559,18 +576,14 @@ def _print_vault_info(
 
     _print_dependency_graph(data)
 
-    click.echo(f"Instant Withdrawal Fuses ({len(data.instant_fuses)}):")
-    _print_fuses_table(data.instant_fuses, chain_id, api_key)
-    click.echo()
-
-    click.echo("ERC20 Balances (vault holdings):")
-    erc20_totals = _print_erc20_balances(ctx, plasma_vault, data)
-    click.echo()
-
     click.echo("Substrates per Market:")
     all_substrate_addrs = _print_substrates(
         ctx, plasma_vault, data.balance_fuses, chain_id, api_key
     )
+    click.echo()
+
+    click.echo("ERC20 Balances (vault holdings):")
+    erc20_totals = _print_erc20_balances(ctx, plasma_vault, data)
     click.echo()
 
     _print_reconciliation(
@@ -685,11 +698,6 @@ def _build_withdraw_manager_json(
     return result
 
 
-def _format_market_label(market_id: int) -> str:
-    label = _market_name(market_id)
-    return f"{label} ({market_id})" if label != "UNKNOWN" else str(market_id)
-
-
 def _build_breakdown_amount_json(
     ctx: Web3Context,
     raw: int,
@@ -791,7 +799,7 @@ def _build_dependency_graph_json(data: _VaultData) -> dict | None:
     }
 
 
-def _build_json_output(  # pylint: disable=too-many-locals,too-complex,too-many-branches
+def _build_json_output(  # pylint: disable=too-many-locals,too-complex,too-many-branches,too-many-statements
     ctx: Web3Context,
     plasma_vault: PlasmaVault,
     data: _VaultData,
@@ -830,12 +838,21 @@ def _build_json_output(  # pylint: disable=too-many-locals,too-complex,too-many-
             for bf in data.balance_fuses
         ]
 
+        fuse_markets = data.fuse_markets or {}
+
+        def _fuse_entry(addr: str, contract: str | None) -> dict:
+            entry: dict = {"address": addr, "contract": contract or "?"}
+            if (mid := fuse_markets.get(addr)) is not None:
+                entry["market_id"] = mid
+                label = _market_name(mid)
+                entry["market"] = label if label != "UNKNOWN" else str(mid)
+            return entry
+
         fuses_json = [
-            {"address": addr, "contract": fuse_name_futs[addr].result() or "?"}
-            for addr in data.fuses
+            _fuse_entry(addr, fuse_name_futs[addr].result()) for addr in data.fuses
         ]
         instant_json = [
-            {"address": addr, "contract": instant_name_futs[addr].result() or "?"}
+            _fuse_entry(addr, instant_name_futs[addr].result())
             for addr in data.instant_fuses
         ]
 
@@ -923,12 +940,7 @@ def _build_json_output(  # pylint: disable=too-many-locals,too-complex,too-many-
         all_sub_addresses: set[str] = set()
         market_subs_raw: list[tuple[str, int, list]] = []
         for i, bf in enumerate(data.balance_fuses):
-            market_label = _market_name(bf.market_id)
-            market_str = (
-                f"{market_label} ({bf.market_id})"
-                if market_label != "UNKNOWN"
-                else str(bf.market_id)
-            )
+            market_str = _format_market_label(bf.market_id)
             if subs := substrate_futs[i].result():
                 market_subs_raw.append((market_str, bf.market_id, subs))
                 for sub in subs:
@@ -1079,7 +1091,11 @@ def _build_json_output(  # pylint: disable=too-many-locals,too-complex,too-many-
     health = _compute_health_check(
         data, bf_totals, erc20_totals, all_sub_lower, plasma_vault
     )
-    health_json = {"ok": health.ok, "warnings": health.warnings}
+    health_json = {
+        "ok": health.ok,
+        "warnings": health.warnings,
+        "criticals": health.criticals,
+    }
 
     explorer_base = BLOCK_EXPLORER_URLS.get(chain_id)
     links: dict[str, str] = {
@@ -1197,18 +1213,59 @@ def _print_pending_requests(data: _VaultData, plasma_vault: PlasmaVault) -> None
     click.echo(f"  Total pending: {total_fmt} shares{total_assets_fmt}")
 
 
-def _print_fuses_table(
-    fuses: Sequence[str], chain_id: int, api_key: str | None
+def _print_fuse_section(  # pylint: disable=too-many-arguments
+    title: str,
+    fuses: Sequence[str],
+    fuse_markets: dict[str, int] | None,
+    market_substrates: dict[int, list[bytes]] | None,
+    chain_id: int,
+    api_key: str | None,
 ) -> None:
+    """Render a fuse section (regular or instant-withdrawal) with a unified
+    layout.
+
+    Fuses are deduplicated by address. The ``Substrates`` column reports
+    how many substrates the fuse's market has registered (read from
+    ``getMarketSubstrates(fuse.MARKET_ID())``) — the actionable surface for
+    the fuse. The header surfaces duplication as ``N unique / M registrations``
+    whenever the same address appears multiple times (typical for
+    instant-withdrawal fuses).
+    """
+    counts: dict[str, int] = {}
+    for addr in fuses:
+        counts[addr] = counts.get(addr, 0) + 1
+
+    total = len(fuses)
+    unique_count = len(counts)
+    suffix = f" / {total} registrations" if total != unique_count else ""
+    click.echo(f"{title} ({unique_count} unique{suffix}):")
+
+    if not counts:
+        click.echo("  (none)")
+        return
+
     with ThreadPoolExecutor() as pool:
-        futures = [
-            (idx, addr, pool.submit(get_contract_name, chain_id, addr, api_key))
-            for idx, addr in enumerate(fuses, 1)
-        ]
+        name_futs = {
+            addr: pool.submit(get_contract_name, chain_id, addr, api_key)
+            for addr in counts
+        }
         rows: list[tuple[str, ...]] = []
-        for idx, addr, fut in futures:
-            rows.append((str(idx), addr, fut.result() or "?"))
-    _print_table(("#", "Address", "Contract"), rows)
+        for idx, addr in enumerate(counts, 1):
+            market_label = "?"
+            substrate_count = "?"
+            if fuse_markets and (mid := fuse_markets.get(addr)) is not None:
+                market_label = _format_market_label(mid)
+                substrate_count = str(len((market_substrates or {}).get(mid, [])))
+            rows.append(
+                (
+                    str(idx),
+                    addr,
+                    name_futs[addr].result() or "?",
+                    market_label,
+                    substrate_count,
+                )
+            )
+    _print_table(("#", "Address", "Contract", "Market", "Substrates"), rows)
 
 
 def _print_balance_fuses_table(
@@ -1225,12 +1282,7 @@ def _print_balance_fuses_table(
     with ThreadPoolExecutor() as pool:
         futures: list[tuple[int, int, str, Future, Future]] = []
         for idx, balance_fuse in enumerate(balance_fuses, 1):
-            market_label = _market_name(balance_fuse.market_id)
-            market_id_str = (
-                f"{market_label} ({balance_fuse.market_id})"
-                if market_label != "UNKNOWN"
-                else str(balance_fuse.market_id)
-            )
+            market_id_str = _format_market_label(balance_fuse.market_id)
             f_balance = pool.submit(
                 plasma_vault.total_assets_in_market, balance_fuse.market_id
             )
@@ -1285,12 +1337,7 @@ def _print_substrates(  # pylint: disable=too-complex
     with ThreadPoolExecutor() as pool:
         substrate_futures: list[tuple[str, int, Future]] = []
         for balance_fuse in balance_fuses:
-            market_label = _market_name(balance_fuse.market_id)
-            market_id_str = (
-                f"{market_label} ({balance_fuse.market_id})"
-                if market_label != "UNKNOWN"
-                else str(balance_fuse.market_id)
-            )
+            market_id_str = _format_market_label(balance_fuse.market_id)
             fut = pool.submit(
                 plasma_vault.get_market_substrates, balance_fuse.market_id
             )

--- a/src/ipor_fusion/cli/vault_dep_graph.py
+++ b/src/ipor_fusion/cli/vault_dep_graph.py
@@ -2,6 +2,97 @@
 
 from __future__ import annotations
 
+from ipor_fusion.market_ids import IporFusionMarkets
+
+
+# Markets where action fuses are intentionally registered without a matching
+# balance fuse. These represent flow-through actions (flash loans, swaps,
+# maintenance) that hold no persistent on-chain position — funds end up tracked
+# either by ERC20_VAULT_BALANCE or by another protocol's balance fuse.
+NO_BALANCE_FUSE_MARKETS: frozenset[int] = frozenset(
+    {
+        IporFusionMarkets.UNISWAP_SWAP_V2,
+        IporFusionMarkets.UNISWAP_SWAP_V3,
+        IporFusionMarkets.UNIVERSAL_TOKEN_SWAPPER,
+        IporFusionMarkets.MORPHO_FLASH_LOAN,
+        IporFusionMarkets.HARVEST_HARD_WORK,
+    }
+)
+
+# uint256 max — sentinel used by burn-request-fee fuses (ZERO_BALANCE_MARKET).
+# Position never touches ERC20 balances, so dependency on ERC20_VAULT_BALANCE
+# is not expected.
+_ZERO_BALANCE_MARKET: int = 2**256 - 1
+
+# Markets that hold non-ERC20 positions (Uniswap LP NFTs, etc.) and would not
+# meaningfully refresh ERC20 cache. Kept narrow so new market types fail loudly
+# until explicitly listed.
+_ERC20_DEP_NOT_REQUIRED: frozenset[int] = frozenset(
+    {
+        IporFusionMarkets.ERC20_VAULT_BALANCE,  # cannot depend on itself
+        _ZERO_BALANCE_MARKET,
+    }
+)
+
+
+def find_orphan_fuse_markets(
+    fuse_markets: dict[str, int],
+    balance_fuse_market_ids: set[int],
+) -> dict[int, list[str]]:
+    """Return markets claimed by action fuses but lacking a balance fuse.
+
+    Such a configuration means positions opened via the action fuse will not
+    contribute to ``totalAssets`` — a silent accounting bug. Markets in
+    ``NO_BALANCE_FUSE_MARKETS`` (flash loans, swaps, maintenance) are excluded
+    because they intentionally have no balance fuse.
+
+    Args:
+        fuse_markets: map of fuse address to market_id (from ``MARKET_ID()``).
+            Entries with ``market_id`` ``None`` are filtered upstream.
+        balance_fuse_market_ids: set of market_ids that currently have a
+            registered balance fuse.
+
+    Returns:
+        Mapping ``market_id -> [fuse_address, ...]`` for orphans, sorted by
+        market_id. Empty dict when configuration is healthy.
+    """
+    orphans: dict[int, list[str]] = {}
+    for fuse_addr, market_id in fuse_markets.items():
+        if market_id in balance_fuse_market_ids:
+            continue
+        if market_id in NO_BALANCE_FUSE_MARKETS:
+            continue
+        orphans.setdefault(market_id, []).append(fuse_addr)
+    return dict(sorted(orphans.items()))
+
+
+def find_markets_missing_erc20_dependency(
+    balance_fuse_market_ids: set[int],
+    dependency_graph: dict[int, list[int]],
+) -> list[int]:
+    """Return balance-fuse markets that should depend on ERC20_VAULT_BALANCE
+    but don't.
+
+    Whenever a market's balance is realised by holding an underlying ERC20
+    (lending pools, vault wrappers, Morpho liquidity, etc.), opening or
+    closing a position changes the vault's ERC20 balance. If that market
+    omits ``ERC20_VAULT_BALANCE`` from its dependency edges, then calling
+    ``updateMarketsBalances(market_id)`` won't refresh the ERC20 cache —
+    ``totalAssets`` then drifts from on-chain reality.
+
+    Markets in ``_ERC20_DEP_NOT_REQUIRED`` (the ERC20 market itself, sentinel
+    burn-fee market) are excluded.
+    """
+    erc20 = IporFusionMarkets.ERC20_VAULT_BALANCE
+    missing: list[int] = []
+    for market_id in sorted(balance_fuse_market_ids):
+        if market_id in _ERC20_DEP_NOT_REQUIRED:
+            continue
+        deps = dependency_graph.get(market_id, [])
+        if erc20 not in deps:
+            missing.append(market_id)
+    return missing
+
 
 def compute_update_reach(graph: dict[int, list[int]]) -> dict[int, set[int]]:
     """For each market with dependencies, compute the transitive closure.

--- a/src/ipor_fusion/cli/vault_fetcher.py
+++ b/src/ipor_fusion/cli/vault_fetcher.py
@@ -79,6 +79,11 @@ class _VaultData:  # pylint: disable=too-many-instance-attributes
     vault_name: str = ""
     deployment_block: int | None = None
     deployment_timestamp: int | None = None
+    # Short error code from `_fetch_deployment_info` when block/timestamp could
+    # not be resolved. Surfaced in CLI output and the JSON `deployment` field
+    # so users can distinguish "lookup not attempted/failed" from
+    # "no deployment exists" (e.g. `etherscan-paid-tier-required` on Base).
+    deployment_error: str | None = None
     withdraw_manager_data: _WithdrawManagerData | None = None
     dependency_graph: dict[int, list[int]] | None = None
     lending_health: VaultLendingHealth | None = None
@@ -520,15 +525,22 @@ def _fetch_deployment_info(
     chain_id: int,
     vault_address: str,
     api_key: str | None,
-) -> tuple[int | None, int | None]:
-    """Return (block, timestamp) for the vault deployment, using cache."""
+) -> tuple[int | None, int | None, str | None]:
+    """Return ``(block, timestamp, error)`` for the vault deployment, using cache.
+
+    ``error`` is a short machine-readable code surfaced to the caller when the
+    lookup fails for a known reason (e.g. ``etherscan-paid-tier-required`` for
+    Base/Optimism on the free Etherscan tier). ``None`` means either success or
+    a benign empty response.
+    """
     cache_key = f"{chain_id}:{vault_address}"
     cache = load_deployment_cache()
     if entry := cache.get(cache_key):
-        return entry["block"], entry["timestamp"]
+        return entry["block"], entry["timestamp"], None
 
-    if not (tx_hash := get_deployment_tx(chain_id, vault_address, api_key)):
-        return None, None
+    tx_hash, error = get_deployment_tx(chain_id, vault_address, api_key)
+    if not tx_hash:
+        return None, None, error
 
     try:
         tx = ctx.web3.eth.get_transaction(HexStr(tx_hash))
@@ -536,6 +548,6 @@ def _fetch_deployment_info(
         block_info = ctx.web3.eth.get_block(block_number)
         timestamp: int = block_info["timestamp"]
         update_deployment_cache(cache_key, block_number, timestamp)
-        return block_number, timestamp
+        return block_number, timestamp, None
     except Exception:  # pylint: disable=broad-except
-        return None, None
+        return None, None, "rpc-fetch-failed"

--- a/src/ipor_fusion/cli/vault_fetcher.py
+++ b/src/ipor_fusion/cli/vault_fetcher.py
@@ -10,6 +10,9 @@ from web3 import Web3
 from web3.exceptions import ContractLogicError, TimeExhausted, Web3RPCError
 from web3.types import ChecksumAddress, HexStr
 
+from eth_abi import decode
+from eth_utils import function_signature_to_4byte_selector
+
 from ipor_fusion.cli.config_store import (
     load_contract_cache,
     load_deployment_cache,
@@ -93,6 +96,15 @@ class _VaultData:  # pylint: disable=too-many-instance-attributes
     # vault's PriceOracleMiddleware. Missing keys mean the oracle has no source
     # configured for that token.
     token_prices_usd: dict[str, float] | None = None
+    # MARKET_ID() reported by each registered action fuse. Keyed by checksummed
+    # fuse address. Fuses that don't expose MARKET_ID() (or whose call reverts)
+    # are absent from the dict — used to detect orphan markets (action fuses
+    # with no matching balance fuse, which silently drop positions from
+    # totalAssets).
+    fuse_markets: dict[str, int] | None = None
+    # Substrates registered for each balance-fuse market. Allows the fuse
+    # tables to report substrate counts per fuse without duplicating reads.
+    market_substrates: dict[int, list[bytes]] | None = None
 
 
 def _safe_call(func: Callable[[], T]) -> T | None:
@@ -101,6 +113,25 @@ def _safe_call(func: Callable[[], T]) -> T | None:
     except (ContractLogicError, Web3RPCError, TimeExhausted) as exc:
         _logger.debug("_safe_call suppressed %s: %s", type(exc).__name__, exc)
         return None
+
+
+_MARKET_ID_SELECTOR = function_signature_to_4byte_selector("MARKET_ID()")
+
+
+def _fetch_fuse_market_id(ctx: Web3Context, fuse_addr: ChecksumAddress) -> int | None:
+    """Read the immutable MARKET_ID() exposed by every IPOR Fusion fuse.
+
+    Returns ``None`` when the call reverts or the fuse contract does not
+    expose the getter (e.g. a non-fuse address ever found in getFuses()).
+    """
+    raw = _safe_call(lambda: ctx.call(fuse_addr, _MARKET_ID_SELECTOR))
+    if not raw:
+        return None
+    try:
+        (value,) = decode(["uint256"], raw)
+    except Exception:  # pylint: disable=broad-except
+        return None
+    return int(value)
 
 
 def _resolve_token_symbol(ctx: Web3Context, address: str) -> str:
@@ -397,6 +428,20 @@ def _fetch_vault_data(  # pylint: disable=too-many-locals
             if deps:
                 dep_graph[market_id] = [int(d) for d in deps]
 
+        # Per-fuse MARKET_ID() — needed to detect orphan markets (action fuse
+        # registered but no balance fuse for the same market_id).
+        fuses_list = f_fuses.result()
+        fuse_market_futs = {
+            addr: pool.submit(_fetch_fuse_market_id, ctx, addr) for addr in fuses_list
+        }
+        fuse_markets: dict[str, int] = {}
+        for addr, fm_fut in fuse_market_futs.items():
+            fuse_mid = fm_fut.result()
+            if fuse_mid is not None:
+                fuse_markets[addr] = fuse_mid
+
+        instant_fuses_list = f_instant.result()
+
         # Phase 5: lending health (Morpho, Aave V3)
         lending_health: VaultLendingHealth | None = None
         if chain_id:
@@ -438,6 +483,7 @@ def _fetch_vault_data(  # pylint: disable=too-many-locals
             morpho_positions = None
             aave_positions = None
             token_prices_usd = None
+            market_substrates = {}
 
         return _VaultData(
             block_label=block_label,
@@ -455,15 +501,17 @@ def _fetch_vault_data(  # pylint: disable=too-many-locals
             rewards_manager=f_rewards.result(),
             withdraw_manager=withdraw_mgr_addr,
             asset_price_usd=asset_price.readable() if asset_price else None,
-            fuses=f_fuses.result(),
+            fuses=fuses_list,
             balance_fuses=balance_fuses,
-            instant_fuses=f_instant.result(),
+            instant_fuses=instant_fuses_list,
             withdraw_manager_data=wm_data,
             dependency_graph=dep_graph or None,
             lending_health=lending_health,
             morpho_positions=morpho_positions,
             aave_positions=aave_positions,
             token_prices_usd=token_prices_usd,
+            fuse_markets=fuse_markets or None,
+            market_substrates=market_substrates or None,
         )
 
 

--- a/src/ipor_fusion/cli/vault_health.py
+++ b/src/ipor_fusion/cli/vault_health.py
@@ -6,13 +6,21 @@ from dataclasses import dataclass, field
 import click
 from web3 import Web3
 
+from ipor_fusion.cli.vault_dep_graph import (
+    find_markets_missing_erc20_dependency,
+    find_orphan_fuse_markets,
+)
 from ipor_fusion.cli.vault_fetcher import (
     _VaultData,
     _resolve_token_symbol,
     _safe_call,
 )
 from ipor_fusion.cli.vault_rendering import _format_amount, _format_usd, _print_table
-from ipor_fusion.cli.vault_substrate import _format_substrate, _market_name
+from ipor_fusion.cli.vault_substrate import (
+    _format_market_label,
+    _format_substrate,
+    _market_name,
+)
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.erc20 import ERC20
 from ipor_fusion.core.oracle import PriceOracleMiddleware
@@ -415,6 +423,53 @@ def _print_reconciliation(
 class _HealthCheckData:
     ok: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    criticals: list[str] = field(default_factory=list)
+
+
+def _compute_orphan_fuse_criticals(data: _VaultData) -> list[str]:
+    """Build CRITICAL lines for action fuses whose market lacks a balance fuse.
+
+    These positions silently bypass ``totalAssets`` accounting. Flow-through
+    markets (flash loans, swaps) are excluded by ``find_orphan_fuse_markets``.
+    """
+    if not data.fuse_markets:
+        return []
+    balance_market_ids = {bf.market_id for bf in data.balance_fuses}
+    orphans = find_orphan_fuse_markets(data.fuse_markets, balance_market_ids)
+    lines: list[str] = []
+    for orphan_mid, fuse_addrs in orphans.items():
+        market_str = _format_market_label(orphan_mid)
+        fuse_list = ", ".join(fuse_addrs)
+        lines.append(
+            f"CRITICAL — action fuse(s) registered for market {market_str} "
+            f"but no balance fuse — positions via these fuses will not "
+            f"contribute to totalAssets: {fuse_list}"
+        )
+    return lines
+
+
+def _compute_missing_erc20_dep_criticals(data: _VaultData) -> list[str]:
+    """Flag balance-fuse markets that don't declare ERC20_VAULT_BALANCE
+    as a dependency.
+
+    Markets backed by the underlying ERC20 (lending, Morpho liquidity, etc.)
+    must include this edge — without it, ``updateMarketsBalances(market)``
+    won't refresh the ERC20 cache and ``totalAssets`` drifts.
+    """
+    balance_market_ids = {bf.market_id for bf in data.balance_fuses}
+    if not balance_market_ids:
+        return []
+    missing = find_markets_missing_erc20_dependency(
+        balance_market_ids, data.dependency_graph or {}
+    )
+    return [
+        f"CRITICAL — market {_format_market_label(mid)} has a balance fuse "
+        f"but its dependency graph omits ERC20_VAULT_BALANCE — "
+        f"updateMarketsBalances({mid}) will not refresh the ERC20 cache, "
+        f"causing totalAssets drift after deposits/withdrawals through this "
+        f"market"
+        for mid in missing
+    ]
 
 
 def _compute_health_check(  # pylint: disable=too-complex
@@ -428,6 +483,9 @@ def _compute_health_check(  # pylint: disable=too-complex
     sym = data.asset_symbol
     underlying = data.asset.lower()
     result = _HealthCheckData()
+
+    result.criticals.extend(_compute_orphan_fuse_criticals(data))
+    result.criticals.extend(_compute_missing_erc20_dep_criticals(data))
 
     # Lending health warnings
     if data.lending_health and data.lending_health.has_lending_positions:
@@ -540,7 +598,9 @@ def _print_health_check(
     click.echo("Health Check:")
     for line in health.ok:
         click.secho(f"  {line}", fg="green")
-    if not health.ok and not health.warnings:
+    if not health.ok and not health.warnings and not health.criticals:
         click.secho("  All checks passed", fg="green")
+    for line in health.criticals:
+        click.secho(f"  {line}", fg="red", bold=True)
     for line in health.warnings:
         click.secho(f"  {line}", fg="yellow")

--- a/src/ipor_fusion/cli/vault_substrate.py
+++ b/src/ipor_fusion/cli/vault_substrate.py
@@ -73,6 +73,28 @@ def _decode_dolomite(hex_str: str) -> _SubstrateInfo:
     )
 
 
+def _decode_euler_v2(hex_str: str) -> _SubstrateInfo:
+    """Decode eulerVault<<96 | isCollateral<<88 | canBorrow<<80 | subAccounts<<72.
+
+    Source: EulerFuseLib.substrateToBytes32 — address occupies the high 20 bytes
+    (left-aligned), followed by three 1-byte flags. Decoding via the generic
+    plain-address path silently produces a malformed address (last 20 bytes are
+    flag bytes + zero padding).
+    """
+    addr = f"0x{hex_str[0:40]}"
+    is_collateral = (int(hex_str[40:42], 16) & 0x01) == 1
+    can_borrow = (int(hex_str[42:44], 16) & 0x01) == 1
+    sub_account = f"0x{hex_str[44:46]}"
+    return _SubstrateInfo(
+        address=addr,
+        extra={
+            "is_collateral": str(is_collateral),
+            "can_borrow": str(can_borrow),
+            "sub_account": sub_account,
+        },
+    )
+
+
 # Market ID → decoder function.  Markets not listed here get raw hex output.
 _SUBSTRATE_DECODERS: dict[int, Callable[[str], _SubstrateInfo]] = {}
 
@@ -97,7 +119,6 @@ _register_markets(
         8,
         9,
         10,
-        11,
         13,
         15,
         16,
@@ -183,6 +204,8 @@ _register_markets(
 _register_markets([38], _decode_enso)
 # Dolomite
 _register_markets([46], _decode_dolomite)
+# Euler V2 (eulerVault<<96 | isCollateral<<88 | canBorrow<<80 | subAccounts<<72)
+_register_markets([11], _decode_euler_v2)
 
 
 def _build_market_lookup() -> dict[int, str]:

--- a/src/ipor_fusion/cli/vault_substrate.py
+++ b/src/ipor_fusion/cli/vault_substrate.py
@@ -202,6 +202,22 @@ def _market_name(market_id: int) -> str:
     return _MARKET_LOOKUP.get(market_id, "UNKNOWN")
 
 
+_UINT256_MAX = 2**256 - 1
+
+
+def _format_market_label(market_id: int) -> str:
+    """Render a market id as ``NAME (id)`` for display.
+
+    Special-cases the ``uint256.max`` sentinel used by burn-fee fuses
+    (ZERO_BALANCE_MARKET) — printing the full 78-digit number is noisy.
+    """
+    if market_id == _UINT256_MAX:
+        name = _market_name(market_id)
+        return f"{name} (uint256.max)" if name != "UNKNOWN" else "uint256.max"
+    label = _market_name(market_id)
+    return f"{label} ({market_id})" if label != "UNKNOWN" else str(market_id)
+
+
 def _format_substrate(raw: bytes, market_id: int | None = None) -> _SubstrateInfo:
     hex_str = raw.hex()
     if len(hex_str) != 64:

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -165,6 +165,112 @@ class ConfigShowResponse(_Base):
     )
 
 
+# ---------------------------------------------------------------------------
+# Market tool models
+# ---------------------------------------------------------------------------
+
+
+class MorphoMarketParamsModel(_Base):
+    loan_token: str
+    collateral_token: str
+    oracle: str
+    irm: str
+    lltv: str = Field(description="LLTV in wad (1e18 = 100%) as a string.")
+
+
+class MorphoMarketStateModel(_Base):
+    total_supply_assets: str
+    total_supply_shares: str
+    total_borrow_assets: str
+    total_borrow_shares: str
+    liquidity_assets: str
+    fee_wad: str
+    last_update: int
+
+
+class MorphoMarketRatesModel(_Base):
+    rate_per_second_wad: str
+    utilization: float
+    borrow_apy: float
+    supply_apy: float
+
+
+class MorphoLoanAssetModel(_Base):
+    address: str
+    symbol: str
+    decimals: int
+
+
+class MorphoVaultPublicAllocatorConfig(_Base):
+    fee_wei: str
+    max_in: str
+    max_out: str
+    admin: str | None = None
+
+
+class MorphoSupplyingVault(_Base):
+    address: str
+    name: str
+    symbol: str
+    asset: dict[str, Any]
+    total_assets: str
+    supply_assets: str
+    supply_cap: str
+    allocators: list[str]
+    public_allocator_config: MorphoVaultPublicAllocatorConfig | None = None
+
+
+class MorphoBlueMarketResponse(_Base):
+    """Morpho Blue market parameters, state, APYs, and supplying vaults."""
+
+    market_id: str
+    chain_id: int
+    public_allocator: str | None = None
+    market_params: MorphoMarketParamsModel
+    state: MorphoMarketStateModel
+    rates: MorphoMarketRatesModel
+    api_error: str | None = None
+    loan_asset: MorphoLoanAssetModel | None = None
+    collateral_asset: MorphoLoanAssetModel | None = None
+    vaults: list[MorphoSupplyingVault] | None = None
+
+
+class MetaMorphoVaultResponse(_Base):
+    """Discriminated by `version` ('v1' or 'v2'). Shape varies between versions
+    — kept loosely typed to avoid duplicating the Morpho API surface."""
+
+    version: str
+    chain_id: int
+    address: str
+    name: str
+    symbol: str
+    asset: dict[str, Any]
+    total_assets: str
+    # v2-only fields
+    idle_assets: str | None = None
+    liquidity: str | None = None
+    share_price: float | None = None
+    max_apy: float | None = None
+    performance_fee: float | None = None
+    performance_fee_recipient: str | None = None
+    management_fee: float | None = None
+    management_fee_recipient: str | None = None
+    sentinels: list[str] | None = None
+    liquidity_adapter: dict[str, Any] | None = None
+    adapters: list[dict[str, Any]] | None = None
+    caps: list[dict[str, Any]] | None = None
+    # v1-only fields
+    fee_wad: str | None = None
+    guardian: str | None = None
+    fee_recipient: str | None = None
+    public_allocator: dict[str, Any] | None = None
+    allocations: list[dict[str, Any]] | None = None
+    # shared
+    owner: str
+    curator: str
+    allocators: list[str]
+
+
 class VaultInfoResponse(_Base):
     """Full on-chain state of a Plasma Vault.
 

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -132,9 +132,11 @@ def vault_info(
 
     api_key = cfg.etherscan_api_key
     chain_label = CHAIN_NAMES.get(chain_id, str(chain_id))
-    data.deployment_block, data.deployment_timestamp = _fetch_deployment_info(
-        ctx, chain_id, vault_address, api_key
-    )
+    (
+        data.deployment_block,
+        data.deployment_timestamp,
+        data.deployment_error,
+    ) = _fetch_deployment_info(ctx, chain_id, vault_address, api_key)
 
     result = _build_json_output(
         ctx, plasma_vault, data, vault_address, chain_id, chain_label, api_key

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -13,6 +13,14 @@ from ipor_fusion.cli.config_store import (
     load_config,
     save_config,
 )
+from ipor_fusion.cli.market_cmd import _build_json as _build_morpho_blue_json
+from ipor_fusion.cli.market_cmd import _meta_morpho_json
+from ipor_fusion.cli.morpho_api import (
+    PUBLIC_ALLOCATOR_ADDRESSES,
+    MorphoApiError,
+    fetch_market,
+    fetch_vault,
+)
 from ipor_fusion.cli.vault_cmd import (
     CHAIN_NAMES,
     _build_json_output,
@@ -26,9 +34,14 @@ from ipor_fusion.core.plasma_vault import PlasmaVault
 from ipor_fusion.mcp.models import (
     ActionResult,
     ConfigShowResponse,
+    MetaMorphoVaultResponse,
+    MorphoBlueMarketResponse,
     VaultInfoResponse,
     VaultListEntry,
 )
+from ipor_fusion.readers.lending_health import MORPHO_BLUE_ADDRESS
+from ipor_fusion.readers.morpho import MorphoReader
+from ipor_fusion.types import MorphoBlueMarketId
 
 mcp = FastMCP("ipor-fusion")
 
@@ -262,6 +275,104 @@ def config_set_etherscan_key(api_key: str) -> ActionResult:
     cfg.etherscan_api_key = api_key
     save_config(cfg)
     return ActionResult(message="Etherscan API key set.")
+
+
+# ---------------------------------------------------------------------------
+# Market tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def market_morpho_blue(
+    market_id: str,
+    chain_id: int,
+    block_number: int = 0,
+    no_api: bool = False,
+) -> MorphoBlueMarketResponse:
+    """Inspect a Morpho Blue market by its 32-byte market ID.
+
+    Returns market parameters, on-chain state + APYs (via IRM `borrowRateView`),
+    and — unless `no_api` is set — the MetaMorpho vaults supplying this market
+    along with their PublicAllocator flow caps and admin addresses.
+
+    Returned JSON fields:
+        market_id, chain_id, public_allocator
+        market_params: { loan_token, collateral_token, oracle, irm, lltv }
+        state: { total_supply_assets, total_supply_shares, total_borrow_assets,
+                 total_borrow_shares, liquidity_assets, fee_wad, last_update }
+        rates: { rate_per_second_wad, utilization, borrow_apy, supply_apy }
+        loan_asset / collateral_asset: { address, symbol, decimals } (when API used)
+        vaults: list of supplying vaults with public_allocator_config flow caps
+        api_error: string if Morpho API call failed (state still returned)
+
+    Args:
+        market_id: 32-byte market ID (0x-prefixed hex or 64 raw hex chars).
+        chain_id: EVM chain ID (1 = Ethereum, 8453 = Base, ...).
+        block_number: Block number for on-chain reads (latest if 0).
+        no_api: Skip Morpho API call (no vault discovery / PublicAllocator info).
+    """
+    raw = market_id.strip().removeprefix("0x").removeprefix("0X").lower()
+    if len(raw) != 64 or not all(c in "0123456789abcdef" for c in raw):
+        raise ValueError(
+            f"invalid Morpho market ID (expected 32-byte hex): {market_id}"
+        )
+
+    cfg = load_config()
+    ctx, _ = _build_ctx(cfg, chain_id, block_number)
+    reader = MorphoReader(ctx, MORPHO_BLUE_ADDRESS)
+    mid = MorphoBlueMarketId(raw)
+    params = reader.market_params(mid)
+    state = reader.market(mid)
+    rates = reader.rates_from(state, params)
+
+    api_market = None
+    api_error: str | None = None
+    if not no_api:
+        try:
+            api_market = fetch_market(raw, chain_id)
+        except MorphoApiError as exc:
+            api_error = str(exc)
+
+    public_allocator = PUBLIC_ALLOCATOR_ADDRESSES.get(chain_id)
+    payload = _build_morpho_blue_json(
+        raw, chain_id, params, state, rates, api_market, api_error, public_allocator
+    )
+    return MorphoBlueMarketResponse.model_validate(payload)
+
+
+@mcp.tool()
+def market_meta_morpho(
+    vault_address: str,
+    chain_id: int,
+) -> MetaMorphoVaultResponse:
+    """Inspect a MetaMorpho V1 or Morpho Vault V2 by address (Morpho API).
+
+    Auto-detects vault version. Returns roles (owner/curator/allocators/sentinels),
+    fees, adapters (V2) or supply allocations (V1), and per-market caps with
+    remaining headroom — useful for deciding whether liquidity can be pushed
+    into a Morpho Blue market via reallocate.
+
+    Returned JSON fields (shape depends on `version`):
+        version: "v1" or "v2"
+        chain_id, address, name, symbol
+        asset: { address, symbol, decimals }
+        total_assets
+        owner, curator, allocators
+        v2 only: idle_assets, liquidity, share_price, max_apy, performance_fee,
+                 performance_fee_recipient, management_fee, management_fee_recipient,
+                 sentinels, liquidity_adapter, adapters, caps
+        v1 only: fee_wad, guardian, fee_recipient, public_allocator, allocations
+
+    Args:
+        vault_address: MetaMorpho V1 or Vault V2 address.
+        chain_id: EVM chain ID.
+    """
+    try:
+        info = fetch_vault(vault_address, chain_id)
+    except MorphoApiError as exc:
+        raise ValueError(str(exc)) from exc
+    payload = _meta_morpho_json(info, chain_id)
+    return MetaMorphoVaultResponse.model_validate(payload)
 
 
 def main() -> None:

--- a/src/ipor_fusion/readers/__init__.py
+++ b/src/ipor_fusion/readers/__init__.py
@@ -1,6 +1,7 @@
 from ipor_fusion.readers.morpho import (
     MorphoReader,
     MorphoMarket,
+    MorphoMarketRates,
     MorphoPosition,
     MorphoMarketParams,
 )
@@ -18,6 +19,7 @@ from ipor_fusion.readers.ramses_v2 import RamsesV2Reader, RamsesV2Position
 __all__ = [
     "MorphoReader",
     "MorphoMarket",
+    "MorphoMarketRates",
     "MorphoPosition",
     "MorphoMarketParams",
     "AaveV3Reader",

--- a/src/ipor_fusion/readers/morpho.py
+++ b/src/ipor_fusion/readers/morpho.py
@@ -1,13 +1,18 @@
 import math
 from dataclasses import dataclass
 
-from eth_abi import decode
+from eth_abi import decode, encode
 from eth_typing import ChecksumAddress
+from eth_utils import function_signature_to_4byte_selector
 from web3 import Web3
 from web3.types import Timestamp
 
 from ipor_fusion.core.contract import ContractWrapper
+from ipor_fusion.core.context import Web3Context
 from ipor_fusion.types import Amount, Fee, MorphoBlueMarketId, Shares
+
+WAD = 10**18
+SECONDS_PER_YEAR = 365 * 24 * 60 * 60  # matches Morpho IRM YEAR constant
 
 
 @dataclass(slots=True)
@@ -40,6 +45,23 @@ class MorphoMarketParams:
     oracle: ChecksumAddress
     irm: ChecksumAddress
     lltv: int
+
+
+@dataclass(slots=True)
+class MorphoMarketRates:
+    """Continuously-compounded APYs for a Morpho Blue market.
+
+    `utilization` is `totalBorrowAssets / totalSupplyAssets` (0.0 if supply is 0).
+    `borrow_apy` is computed from the IRM's `borrowRateView` rate-per-second using
+    continuous compounding (`exp(r * YEAR) - 1`), matching what the Morpho UI shows.
+    `supply_apy` accounts for utilization and the protocol fee.
+    `rate_per_second_wad` is the raw rate returned by the IRM, scaled by 1e18.
+    """
+
+    rate_per_second_wad: int
+    utilization: float
+    borrow_apy: float
+    supply_apy: float
 
 
 @dataclass(slots=True)
@@ -131,3 +153,79 @@ class MorphoReader(ContractWrapper):
             irm=Web3.to_checksum_address(irm),
             lltv=lltv,
         )
+
+    def rates(self, market_id: MorphoBlueMarketId) -> MorphoMarketRates:
+        """Read the IRM and derive supply/borrow APYs for the market.
+
+        Calls `borrowRateView(marketParams, market)` on the market's IRM contract.
+        APY is continuously compounded using `SECONDS_PER_YEAR = 365 * 86400`,
+        matching how the Morpho frontend displays rates.
+        """
+        market = self.market(market_id)
+        params = self.market_params(market_id)
+        return self.rates_from(market, params)
+
+    def rates_from(
+        self, market: MorphoMarket, params: MorphoMarketParams
+    ) -> MorphoMarketRates:
+        """Compute APYs given pre-fetched market state and params.
+
+        Use this when the caller has already read `market()` and `market_params()`
+        to avoid two redundant RPC roundtrips.
+        """
+        rate_wad = _irm_borrow_rate_view(self._ctx, params, market)
+        rate = rate_wad / WAD
+        borrow_apy = math.expm1(rate * SECONDS_PER_YEAR)
+        if market.total_supply_assets > 0:
+            utilization = market.total_borrow_assets / market.total_supply_assets
+        else:
+            utilization = 0.0
+        fee_factor = 1.0 - market.fee / WAD
+        supply_apy = borrow_apy * utilization * fee_factor
+        return MorphoMarketRates(
+            rate_per_second_wad=rate_wad,
+            utilization=utilization,
+            borrow_apy=borrow_apy,
+            supply_apy=supply_apy,
+        )
+
+
+def _irm_borrow_rate_view(
+    ctx: Web3Context, params: MorphoMarketParams, market: MorphoMarket
+) -> int:
+    """Call `borrowRateView((MarketParams),(Market))` on the IRM contract.
+
+    Returns the rate per second, scaled by 1e18 (Morpho convention).
+    """
+    selector = function_signature_to_4byte_selector(
+        "borrowRateView("
+        "(address,address,address,address,uint256),"
+        "(uint128,uint128,uint128,uint128,uint128,uint128)"
+        ")"
+    )
+    payload = encode(
+        [
+            "(address,address,address,address,uint256)",
+            "(uint128,uint128,uint128,uint128,uint128,uint128)",
+        ],
+        [
+            (
+                params.loan_token,
+                params.collateral_token,
+                params.oracle,
+                params.irm,
+                params.lltv,
+            ),
+            (
+                market.total_supply_assets,
+                market.total_supply_shares,
+                market.total_borrow_assets,
+                market.total_borrow_shares,
+                market.last_update,
+                market.fee,
+            ),
+        ],
+    )
+    raw = ctx.call(params.irm, selector + payload)
+    (rate,) = decode(["uint256"], raw)
+    return rate

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -338,7 +338,7 @@ class TestVaultInfo:
         assert ADDR_ORACLE in result.output
         assert ADDR_REWARDS in result.output
         assert ADDR_WITHDRAW in result.output
-        assert "Fuses (2)" in result.output
+        assert "Fuses (2 unique)" in result.output
         assert "Balance Fuses (1)" in result.output
         assert "SomeFuse" in result.output
         assert "Window:" in result.output

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -535,7 +535,10 @@ class TestVaultInfo:
             in result.output
         )
 
-    @patch("ipor_fusion.cli.vault_fetcher.get_deployment_tx", return_value="0xdeadbeef")
+    @patch(
+        "ipor_fusion.cli.vault_fetcher.get_deployment_tx",
+        return_value=("0xdeadbeef", None),
+    )
     @patch("ipor_fusion.cli.vault_cmd.get_contract_name", return_value="SomeFuse")
     @patch("ipor_fusion.cli.vault_fetcher.PriceOracleMiddleware")
     @patch("ipor_fusion.cli.vault_fetcher.ERC20")
@@ -793,7 +796,10 @@ class TestVaultInfoJson:
         assert (
             data["links"]["ipor_app"] == f"https://app.ipor.io/fusion/ethereum/{ADDR_1}"
         )
-        assert data["deployment"] is None
+        # Test fixture omits the Etherscan API key — surface that as a structured
+        # error rather than silently emitting null, so callers can distinguish
+        # "lookup not attempted" from "no deployment tx exists".
+        assert data["deployment"] == {"error": "no-api-key"}
         subs = data["substrates"]["MORPHO (14)"]
         assert len(subs) == 1
         assert "raw" in subs[0]
@@ -811,7 +817,10 @@ class TestVaultInfoJson:
         assert wmd["pending_requests"][0]["account"] == ADDR_USER_1
         assert wmd["pending_requests"][0]["can_withdraw"] is True
 
-    @patch("ipor_fusion.cli.vault_fetcher.get_deployment_tx", return_value="0xdeadbeef")
+    @patch(
+        "ipor_fusion.cli.vault_fetcher.get_deployment_tx",
+        return_value=("0xdeadbeef", None),
+    )
     @patch("ipor_fusion.cli.vault_cmd.get_contract_name", return_value="SomeFuse")
     @patch("ipor_fusion.cli.vault_fetcher.PriceOracleMiddleware")
     @patch("ipor_fusion.cli.vault_fetcher.ERC20")

--- a/tests/test_cli_explorer.py
+++ b/tests/test_cli_explorer.py
@@ -5,9 +5,11 @@ import pytest
 
 from ipor_fusion.cli import config_store
 from ipor_fusion.cli.explorer import (
+    _fetch_contract_creation_tx,
     _fetch_contract_name,
     _fetch_getsourcecode,
     get_contract_name,
+    get_deployment_tx,
 )
 
 
@@ -141,3 +143,62 @@ class TestFetchGetSourceCode:
     def test_network_error_returns_none(self, mock_urlopen_fn):
         mock_urlopen_fn.side_effect = OSError("connection refused")
         assert _fetch_getsourcecode(1, "0xABC", api_key="key123") is None
+
+
+class TestFetchContractCreationTx:
+    def test_unsupported_chain(self):
+        tx, err = _fetch_contract_creation_tx(99999, "0xABC", api_key="key123")
+        assert tx is None
+        assert err == "chain-not-supported"
+
+    def test_no_api_key(self):
+        tx, err = _fetch_contract_creation_tx(1, "0xABC", api_key=None)
+        assert tx is None
+        assert err == "no-api-key"
+
+    @patch("ipor_fusion.cli.explorer.urlopen")
+    def test_paid_tier_required(self, mock_urlopen_fn):
+        response = {
+            "status": "0",
+            "message": "NOTOK",
+            "result": (
+                "Free API access is not supported for this chain. "
+                "Please upgrade your api plan for full chain coverage."
+            ),
+        }
+        mock_urlopen_fn.return_value = _mock_urlopen(json.dumps(response).encode())
+        tx, err = _fetch_contract_creation_tx(8453, "0xABC", api_key="key123")
+        assert tx is None
+        assert err == "etherscan-paid-tier-required"
+
+    @patch("ipor_fusion.cli.explorer.urlopen")
+    def test_no_data_found_is_not_an_error(self, mock_urlopen_fn):
+        response = {"status": "0", "message": "No data found", "result": []}
+        mock_urlopen_fn.return_value = _mock_urlopen(json.dumps(response).encode())
+        tx, err = _fetch_contract_creation_tx(1, "0xABC", api_key="key123")
+        assert tx is None
+        assert err is None
+
+    @patch("ipor_fusion.cli.explorer.urlopen")
+    def test_success_returns_tx_hash(self, mock_urlopen_fn):
+        response = {
+            "status": "1",
+            "result": [{"txHash": "0xdeadbeef"}],
+        }
+        mock_urlopen_fn.return_value = _mock_urlopen(json.dumps(response).encode())
+        tx, err = _fetch_contract_creation_tx(1, "0xABC", api_key="key123")
+        assert tx == "0xdeadbeef"
+        assert err is None
+
+    @patch("ipor_fusion.cli.explorer.urlopen")
+    def test_network_error(self, mock_urlopen_fn):
+        mock_urlopen_fn.side_effect = OSError("connection refused")
+        tx, err = _fetch_contract_creation_tx(1, "0xABC", api_key="key123")
+        assert tx is None
+        assert err == "fetch-failed"
+
+    def test_get_deployment_tx_delegates(self):
+        # Smoke test the public alias.
+        tx, err = get_deployment_tx(99999, "0xABC", api_key="key123")
+        assert tx is None
+        assert err == "chain-not-supported"

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -327,6 +327,25 @@ class TestFormatSubstratePerMarket:
         assert info.extra["sub_account_id"] == "5"
         assert info.extra["can_borrow"] == "True"
 
+    # Euler V2 (eulerVault<<96 | isCollateral<<88 | canBorrow<<80 | subAccounts<<72)
+    def test_euler_v2_supply_only(self):
+        addr_hex = "ab" * 20
+        raw = bytes.fromhex(addr_hex + "00" + "00" + "00" + "00" * 9)
+        info = _format_substrate(raw, market_id=11)
+        assert info.address == f"0x{addr_hex}"
+        assert info.extra["is_collateral"] == "False"
+        assert info.extra["can_borrow"] == "False"
+        assert info.extra["sub_account"] == "0x00"
+
+    def test_euler_v2_collateral_borrow_subaccount(self):
+        addr_hex = "cd" * 20
+        raw = bytes.fromhex(addr_hex + "01" + "01" + "07" + "00" * 9)
+        info = _format_substrate(raw, market_id=11)
+        assert info.address == f"0x{addr_hex}"
+        assert info.extra["is_collateral"] == "True"
+        assert info.extra["can_borrow"] == "True"
+        assert info.extra["sub_account"] == "0x07"
+
     # Unknown market — raw hex with no_decoder label
     def test_unknown_market(self):
         raw = bytes.fromhex("ff" * 32)

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -18,6 +18,7 @@ from ipor_fusion.cli.vault_cmd import (
     _build_share_price_json,
     _index_lending_health,
     _print_dependency_graph,
+    _print_fuse_section,
     _print_health_lines,
     _print_lending_health,
     _print_pending_requests,
@@ -33,6 +34,7 @@ from ipor_fusion.cli.vault_fetcher import (
     _collect_morpho_substrates,
     _fetch_aave_positions,
     _fetch_breakdown_token_prices,
+    _fetch_fuse_market_id,
     _fetch_morpho_positions,
     _resolve_token_symbol,
     _safe_call,
@@ -1685,3 +1687,117 @@ class TestPrintPendingRequests:
         _print_pending_requests(data, pv)
         captured = capsys.readouterr()
         assert "Pending requests: (none)" in captured.out
+
+
+class TestPrintFuseSection:
+    """Single unified renderer used by both Fuses and Instant Withdrawal
+    Fuses. Dedupes by address, reports a Registrations column, and surfaces
+    duplicate registrations in the section header."""
+
+    @patch(
+        "ipor_fusion.cli.vault_cmd.get_contract_name", return_value="MorphoSupplyFuse"
+    )
+    def test_renders_market_label_and_substrate_count(self, _mock_name, capsys):
+        addr = ADDR_1
+        _print_fuse_section(
+            "Fuses",
+            [addr],
+            fuse_markets={addr: IporFusionMarkets.MORPHO},
+            market_substrates={IporFusionMarkets.MORPHO: [b"\x11" * 32, b"\x22" * 32]},
+            chain_id=1,
+            api_key=None,
+        )
+        captured = capsys.readouterr()
+        assert "Fuses (1 unique)" in captured.out
+        assert "MORPHO" in captured.out
+        assert addr in captured.out
+        assert "Substrates" in captured.out
+        # Substrate count comes from market_substrates, not from registrations
+        assert "  2  " in captured.out or "2\n" in captured.out
+
+    @patch("ipor_fusion.cli.vault_cmd.get_contract_name", return_value="UnknownFuse")
+    def test_renders_question_mark_without_fuse_markets(self, _mock_name, capsys):
+        _print_fuse_section(
+            "Fuses",
+            [ADDR_1],
+            fuse_markets=None,
+            market_substrates=None,
+            chain_id=1,
+            api_key=None,
+        )
+        captured = capsys.readouterr()
+        assert "?" in captured.out
+
+    @patch(
+        "ipor_fusion.cli.vault_cmd.get_contract_name", return_value="MorphoSupplyFuse"
+    )
+    def test_dedupes_repeated_fuse_address(self, _mock_name, capsys):
+        addr = ADDR_1
+        _print_fuse_section(
+            "Instant Withdrawal Fuses",
+            [addr, addr, addr],
+            fuse_markets={addr: IporFusionMarkets.MORPHO},
+            market_substrates={IporFusionMarkets.MORPHO: [b"\x11" * 32] * 3},
+            chain_id=1,
+            api_key=None,
+        )
+        captured = capsys.readouterr()
+        assert "1 unique / 3 registrations" in captured.out
+        assert captured.out.count(addr) == 1
+
+    @patch(
+        "ipor_fusion.cli.vault_cmd.get_contract_name", return_value="MorphoSupplyFuse"
+    )
+    def test_no_registrations_suffix_when_unique(self, _mock_name, capsys):
+        _print_fuse_section(
+            "Fuses",
+            [ADDR_1, ADDR_2],
+            fuse_markets=None,
+            market_substrates=None,
+            chain_id=1,
+            api_key=None,
+        )
+        captured = capsys.readouterr()
+        assert "registrations" not in captured.out
+        assert "2 unique" in captured.out
+
+    def test_empty_input(self, capsys):
+        _print_fuse_section(
+            "Instant Withdrawal Fuses",
+            [],
+            fuse_markets=None,
+            market_substrates=None,
+            chain_id=1,
+            api_key=None,
+        )
+        captured = capsys.readouterr()
+        assert "(none)" in captured.out
+
+
+class TestFetchFuseMarketId:
+    """Reads the immutable MARKET_ID() exposed by every IPOR Fusion fuse so
+    the CLI can detect orphan markets (action fuses without a matching
+    balance fuse)."""
+
+    def test_returns_decoded_uint256(self):
+        ctx = MagicMock()
+        # uint256(14) ABI-encoded
+        ctx.call.return_value = (14).to_bytes(32, "big")
+        result = _fetch_fuse_market_id(ctx, ADDR_1)
+        assert result == 14
+        ctx.call.assert_called_once()
+
+    def test_returns_none_on_revert(self):
+        ctx = MagicMock()
+        ctx.call.side_effect = ContractLogicError("execution reverted")
+        assert _fetch_fuse_market_id(ctx, ADDR_1) is None
+
+    def test_returns_none_on_empty_response(self):
+        ctx = MagicMock()
+        ctx.call.return_value = b""
+        assert _fetch_fuse_market_id(ctx, ADDR_1) is None
+
+    def test_returns_none_on_undecodable_response(self):
+        ctx = MagicMock()
+        ctx.call.return_value = b"\x00\x01"  # too short for uint256
+        assert _fetch_fuse_market_id(ctx, ADDR_1) is None

--- a/tests/test_cli_lending_health.py
+++ b/tests/test_cli_lending_health.py
@@ -670,3 +670,152 @@ class TestHealthCheckLendingWarnings:
 
         # Only the standard reconciliation check, no lending warnings
         assert not any("CRITICAL" in w for w in health.warnings)
+
+
+class TestOrphanFuseMarketsHealthCheck:
+    """The CLI must flag a critical when an action fuse claims a market that
+    has no balance fuse — positions opened via that fuse silently bypass
+    totalAssets accounting (the misconfiguration scenario reported by users)."""
+
+    def _make_data(self, fuse_markets, balance_fuses, dependency_graph=None):
+        from ipor_fusion.cli.vault_fetcher import _VaultData
+
+        addr = Web3.to_checksum_address("0x" + "11" * 20)
+        return _VaultData(
+            block_label="123",
+            block_timestamp=1700000000,
+            share_decimals=18,
+            asset_decimals=18,
+            total_assets=100 * 10**18,
+            total_supply=100 * 10**18,
+            supply_cap=0,
+            asset=addr,
+            vault_name="Test",
+            asset_symbol="USDC",
+            access_manager=addr,
+            price_oracle_addr=addr,
+            rewards_manager=None,
+            withdraw_manager=None,
+            asset_price_usd=1.0,
+            fuses=list(fuse_markets.keys()) if fuse_markets else [],
+            balance_fuses=balance_fuses,
+            instant_fuses=[],
+            fuse_markets=fuse_markets,
+            dependency_graph=dependency_graph,
+        )
+
+    def test_morpho_orphan_marked_critical(self):
+        from ipor_fusion.cli.vault_health import (
+            _BalanceFuseTotals,
+            _Erc20Totals,
+            _compute_health_check,
+        )
+        from ipor_fusion.core.plasma_vault import BalanceFuse
+
+        fuse_addr = "0x" + "aa" * 20
+        balance_fuse = BalanceFuse(
+            market_id=IporFusionMarkets.ERC20_VAULT_BALANCE,
+            fuse=Web3.to_checksum_address("0x" + "bb" * 20),
+        )
+        data = self._make_data(
+            fuse_markets={fuse_addr: IporFusionMarkets.MORPHO},
+            balance_fuses=[balance_fuse],
+        )
+
+        health = _compute_health_check(
+            data, _BalanceFuseTotals(raw_total=100 * 10**18), _Erc20Totals(), set()
+        )
+
+        assert len(health.criticals) == 1
+        line = health.criticals[0]
+        assert "CRITICAL" in line
+        assert "MORPHO" in line
+        assert fuse_addr in line
+        assert "totalAssets" in line
+
+    def test_flash_loan_action_fuse_not_flagged(self):
+        from ipor_fusion.cli.vault_health import (
+            _BalanceFuseTotals,
+            _Erc20Totals,
+            _compute_health_check,
+        )
+
+        data = self._make_data(
+            fuse_markets={"0x" + "cc" * 20: IporFusionMarkets.MORPHO_FLASH_LOAN},
+            balance_fuses=[],
+        )
+
+        health = _compute_health_check(
+            data, _BalanceFuseTotals(), _Erc20Totals(), set()
+        )
+
+        assert not health.criticals
+
+    def test_no_fuse_markets_no_criticals(self):
+        from ipor_fusion.cli.vault_health import (
+            _BalanceFuseTotals,
+            _Erc20Totals,
+            _compute_health_check,
+        )
+
+        data = self._make_data(fuse_markets=None, balance_fuses=[])
+        health = _compute_health_check(
+            data, _BalanceFuseTotals(), _Erc20Totals(), set()
+        )
+        assert not health.criticals
+
+    def test_balance_fuse_market_missing_erc20_dep_marked_critical(self):
+        """The Base vault case: balance fuse for MORPHO_LIQUIDITY_IN_MARKETS
+        (41) exists, but its dependency graph entry doesn't include
+        ERC20_VAULT_BALANCE — updateMarketsBalances(41) silently skips the
+        ERC20 cache refresh."""
+        from ipor_fusion.cli.vault_health import (
+            _BalanceFuseTotals,
+            _Erc20Totals,
+            _compute_health_check,
+        )
+        from ipor_fusion.core.plasma_vault import BalanceFuse
+
+        morpho_lim = 41
+        bf = BalanceFuse(
+            market_id=morpho_lim, fuse=Web3.to_checksum_address("0x" + "bb" * 20)
+        )
+        data = self._make_data(
+            fuse_markets=None,
+            balance_fuses=[bf],
+            dependency_graph={},
+        )
+
+        health = _compute_health_check(
+            data, _BalanceFuseTotals(), _Erc20Totals(), set()
+        )
+
+        critical_lines = [c for c in health.criticals if "ERC20_VAULT_BALANCE" in c]
+        assert len(critical_lines) == 1
+        assert "(41)" in critical_lines[0]
+
+    def test_balance_fuse_with_correct_erc20_dep_no_critical(self):
+        from ipor_fusion.cli.vault_health import (
+            _BalanceFuseTotals,
+            _Erc20Totals,
+            _compute_health_check,
+        )
+        from ipor_fusion.core.plasma_vault import BalanceFuse
+
+        bf = BalanceFuse(
+            market_id=IporFusionMarkets.EULER_V2,
+            fuse=Web3.to_checksum_address("0x" + "bb" * 20),
+        )
+        data = self._make_data(
+            fuse_markets=None,
+            balance_fuses=[bf],
+            dependency_graph={
+                IporFusionMarkets.EULER_V2: [IporFusionMarkets.ERC20_VAULT_BALANCE]
+            },
+        )
+
+        health = _compute_health_check(
+            data, _BalanceFuseTotals(), _Erc20Totals(), set()
+        )
+
+        assert not [c for c in health.criticals if "ERC20_VAULT_BALANCE" in c]

--- a/tests/test_cli_market_morpho_blue.py
+++ b/tests/test_cli_market_morpho_blue.py
@@ -1,0 +1,703 @@
+"""Unit tests for `fusion market morpho-blue` and the Morpho API client."""
+
+# pylint: disable=unused-argument
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from eth_abi import encode
+from web3 import Web3
+
+from ipor_fusion.cli import config_store
+from ipor_fusion.cli.config_store import FusionConfig, save_config
+from ipor_fusion.cli.main import cli
+from ipor_fusion.cli.morpho_api import (
+    MorphoApiError,
+    MorphoApiMarket,
+    VaultAllocation,
+    VaultFlowCap,
+    fetch_market,
+    fetch_vault,
+)
+
+MARKET_ID = "ad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc"
+LOAN_TOKEN = Web3.to_checksum_address("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+COLLATERAL_TOKEN = Web3.to_checksum_address(
+    "0xd2af830e8cbdfed6cc11bab697bb25496ed6fa62"
+)
+ORACLE = Web3.to_checksum_address("0x7c65985c35181d51ef7571fa40211b57659b7d80")
+IRM = Web3.to_checksum_address("0x870ac11d48b15db9a138cf899d20f13f79ba00bc")
+VAULT_ADDR = Web3.to_checksum_address("0xf9bddd4a9b3a45f980e11fdde96e16364ddbec49")
+
+
+def _market_raw(supply=1_008_277, borrow=908_170, fee=0):
+    return encode(
+        ["uint128", "uint128", "uint128", "uint128", "uint128", "uint128"],
+        [supply, supply, borrow, borrow, 1700000000, fee],
+    )
+
+
+def _params_raw():
+    return encode(
+        ["address", "address", "address", "address", "uint256"],
+        [LOAN_TOKEN, COLLATERAL_TOKEN, ORACLE, IRM, 915 * 10**15],
+    )
+
+
+def _rate_raw(rate_wad=10**9):
+    return encode(["uint256"], [rate_wad])
+
+
+PUBLIC_ALLOCATOR_ETH = "0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D"
+ADMIN_ADDR = "0x75a1253432356f90611546a487b5350CEF08780D"
+
+
+def _api_market(with_flow_cap=True, role_granted=True):
+    flow_cap = (
+        VaultFlowCap(
+            fee_wei=0,
+            max_in=749_817_674_338,
+            max_out=2_000_182_325_662,
+            admin=ADMIN_ADDR,
+        )
+        if with_flow_cap
+        else None
+    )
+    allocators = [ADMIN_ADDR]
+    if role_granted:
+        allocators = [PUBLIC_ALLOCATOR_ETH] + allocators
+    vault = VaultAllocation(
+        vault_address=VAULT_ADDR,
+        vault_name="Yearn OG USDC",
+        vault_symbol="ymvOG-USDC",
+        asset_symbol="USDC",
+        asset_decimals=6,
+        total_assets=2_026_303_515_163,
+        supply_assets=0,
+        supply_cap=1_500_000_000_000,
+        allocators=allocators,
+        flow_cap=flow_cap,
+    )
+    return MorphoApiMarket(
+        market_id="0x" + MARKET_ID,
+        lltv=915 * 10**15,
+        loan_token=LOAN_TOKEN,
+        loan_symbol="USDC",
+        loan_decimals=6,
+        collateral_token=COLLATERAL_TOKEN,
+        collateral_symbol="WOUSD",
+        collateral_decimals=18,
+        oracle=ORACLE,
+        irm=IRM,
+        supply_assets=1_008_277,
+        borrow_assets=908_170,
+        liquidity_assets=100_107,
+        utilization=0.9007,
+        supply_apy=0.0327,
+        borrow_apy=0.0364,
+        fee_wad=0,
+        timestamp=1777532711,
+        vaults=[vault],
+    )
+
+
+def _setup_provider(tmp_path, monkeypatch):
+    config_dir = tmp_path / ".fusion"
+    config_file = config_dir / "config.json"
+    cache_dir = tmp_path / ".cache"
+    monkeypatch.setattr(config_store, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_store, "CONFIG_FILE", config_file)
+    monkeypatch.setattr(config_store, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(config_store, "CACHE_FILE", cache_dir / "contract_cache.json")
+    monkeypatch.setattr(
+        config_store,
+        "DEPLOYMENT_CACHE_FILE",
+        cache_dir / "deployment_cache.json",
+    )
+    save_config(
+        FusionConfig(
+            providers={"1": "https://rpc.example.com"},
+            etherscan_api_key=None,
+            vaults=[],
+        )
+    )
+
+
+@patch("ipor_fusion.cli.market_cmd.fetch_market")
+@patch("ipor_fusion.cli.market_cmd.Web3Context")
+class TestMorphoBlueCommand:
+    def test_renders_market_state_and_vaults(
+        self, mock_ctx_cls, mock_fetch, tmp_path, monkeypatch
+    ):
+        _setup_provider(tmp_path, monkeypatch)
+        ctx = MagicMock()
+        # Command path: market_params() → market() → rates()
+        # rates() internally reads market() + market_params() + IRM
+        # market_params() → market() → IRM borrowRateView()
+        ctx.call.side_effect = [
+            _params_raw(),
+            _market_raw(),
+            _rate_raw(),
+        ]
+        mock_ctx_cls.from_url.return_value = ctx
+        mock_fetch.return_value = _api_market()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["market", "morpho-blue", MARKET_ID, "--chain", "ethereum"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Morpho Blue market 0x" + MARKET_ID in result.output
+        assert "ethereum (id 1)" in result.output
+        assert LOAN_TOKEN in result.output
+        assert COLLATERAL_TOKEN in result.output
+        assert ORACLE in result.output
+        assert IRM in result.output
+        assert "91.50%" in result.output  # LLTV
+        assert "Borrow APY" in result.output
+        assert "Supply APY" in result.output
+        # PublicAllocator singleton
+        assert PUBLIC_ALLOCATOR_ETH in result.output
+        # Connected vaults section
+        assert "ymvOG-USDC" in result.output
+        assert VAULT_ADDR in result.output
+        assert "fee 0.000000 ETH" in result.output
+        # Per-vault allocators block + role flag
+        assert "Allocators for ymvOG-USDC" in result.output
+        assert "PublicAllocator — public reallocate enabled" in result.output
+        assert "PublicAllocator admin" in result.output
+        # Reallocate hint
+        assert "Reallocate parameters" in result.output
+
+    def test_no_api_skips_vault_section(
+        self, mock_ctx_cls, mock_fetch, tmp_path, monkeypatch
+    ):
+        _setup_provider(tmp_path, monkeypatch)
+        ctx = MagicMock()
+        # market_params() → market() → IRM borrowRateView()
+        ctx.call.side_effect = [
+            _params_raw(),
+            _market_raw(),
+            _rate_raw(),
+        ]
+        mock_ctx_cls.from_url.return_value = ctx
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["market", "morpho-blue", MARKET_ID, "--chain", "1", "--no-api"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_fetch.call_count == 0
+        assert "skipped (--no-api)" in result.output
+
+    def test_api_failure_renders_warning_but_succeeds(
+        self, mock_ctx_cls, mock_fetch, tmp_path, monkeypatch
+    ):
+        _setup_provider(tmp_path, monkeypatch)
+        ctx = MagicMock()
+        # market_params() → market() → IRM borrowRateView()
+        ctx.call.side_effect = [
+            _params_raw(),
+            _market_raw(),
+            _rate_raw(),
+        ]
+        mock_ctx_cls.from_url.return_value = ctx
+        mock_fetch.side_effect = MorphoApiError("network down")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["market", "morpho-blue", MARKET_ID, "--chain", "1"]
+        )
+
+        assert result.exit_code == 0
+        assert "unavailable (network down)" in result.output
+
+    def test_json_output(self, mock_ctx_cls, mock_fetch, tmp_path, monkeypatch):
+        _setup_provider(tmp_path, monkeypatch)
+        ctx = MagicMock()
+        # market_params() → market() → IRM borrowRateView()
+        ctx.call.side_effect = [
+            _params_raw(),
+            _market_raw(),
+            _rate_raw(),
+        ]
+        mock_ctx_cls.from_url.return_value = ctx
+        mock_fetch.return_value = _api_market()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["market", "morpho-blue", MARKET_ID, "--chain", "1", "--json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["market_id"] == "0x" + MARKET_ID
+        assert data["chain_id"] == 1
+        assert data["market_params"]["loan_token"] == LOAN_TOKEN
+        assert data["market_params"]["irm"] == IRM
+        assert data["state"]["liquidity_assets"] == "100107"  # supply - borrow
+        assert "borrow_apy" in data["rates"]
+        assert data["public_allocator"] == PUBLIC_ALLOCATOR_ETH
+        assert len(data["vaults"]) == 1
+        vault_json = data["vaults"][0]
+        assert vault_json["public_allocator_config"]["max_in"] == "749817674338"
+        assert vault_json["public_allocator_config"]["admin"] == ADMIN_ADDR
+        assert PUBLIC_ALLOCATOR_ETH in vault_json["allocators"]
+
+    def test_invalid_market_id_rejected(
+        self, mock_ctx_cls, mock_fetch, tmp_path, monkeypatch
+    ):
+        _setup_provider(tmp_path, monkeypatch)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["market", "morpho-blue", "0xdead", "--chain", "1"])
+        assert result.exit_code != 0
+        assert "invalid Morpho market ID" in result.output
+
+
+class TestMorphoApiClient:
+    def test_fetch_market_parses_full_response(self):
+        body = {
+            "data": {
+                "marketById": {
+                    "marketId": "0x" + MARKET_ID,
+                    "lltv": "915000000000000000",
+                    "loanAsset": {
+                        "address": LOAN_TOKEN,
+                        "symbol": "USDC",
+                        "decimals": 6,
+                    },
+                    "collateralAsset": {
+                        "address": COLLATERAL_TOKEN,
+                        "symbol": "WOUSD",
+                        "decimals": 18,
+                    },
+                    "oracle": {"address": ORACLE},
+                    "irmAddress": IRM,
+                    "state": {
+                        "supplyAssets": 1008277,
+                        "borrowAssets": 908170,
+                        "liquidityAssets": 100107,
+                        "utilization": 0.9,
+                        "supplyApy": 0.03,
+                        "borrowApy": 0.036,
+                        "fee": 0,
+                        "timestamp": 1777532711,
+                    },
+                    "supplyingVaults": [
+                        {
+                            "address": VAULT_ADDR,
+                            "symbol": "ymvOG-USDC",
+                            "name": "Yearn OG USDC",
+                            "asset": {"symbol": "USDC", "decimals": 6},
+                            "state": {
+                                "totalAssets": 2026303515163,
+                                "allocation": [
+                                    {
+                                        "market": {"marketId": "0x" + MARKET_ID},
+                                        "supplyAssets": 0,
+                                        "supplyCap": 1500000000000,
+                                    },
+                                    {
+                                        "market": {"marketId": "0xdeadbeef"},
+                                        "supplyAssets": 99,
+                                        "supplyCap": 0,
+                                    },
+                                ],
+                            },
+                            "allocators": [
+                                {"address": PUBLIC_ALLOCATOR_ETH},
+                                {"address": ADMIN_ADDR},
+                            ],
+                            "publicAllocatorConfig": {
+                                "fee": 0,
+                                "admin": ADMIN_ADDR,
+                                "flowCaps": [
+                                    {
+                                        "market": {"marketId": "0x" + MARKET_ID},
+                                        "maxIn": 749817674338,
+                                        "maxOut": 2000182325662,
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                }
+            }
+        }
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(body).encode()
+            mock_open.return_value.__enter__.return_value = mock_resp
+
+            result = fetch_market(MARKET_ID, 1)
+
+        assert result.market_id == "0x" + MARKET_ID
+        assert result.lltv == 915 * 10**15
+        assert result.loan_symbol == "USDC"
+        assert len(result.vaults) == 1
+        vault = result.vaults[0]
+        assert vault.vault_symbol == "ymvOG-USDC"
+        # Picks the allocation matching this market, not the deadbeef one
+        assert vault.supply_assets == 0
+        assert vault.supply_cap == 1500000000000
+        assert vault.flow_cap is not None
+        assert vault.flow_cap.max_in == 749817674338
+        assert vault.flow_cap.fee_wei == 0
+        assert vault.flow_cap.admin == ADMIN_ADDR
+        assert vault.allocators == [PUBLIC_ALLOCATOR_ETH, ADMIN_ADDR]
+
+    def test_fetch_market_handles_missing_market(self):
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(
+                {"data": {"marketById": None}}
+            ).encode()
+            mock_open.return_value.__enter__.return_value = mock_resp
+
+            try:
+                fetch_market(MARKET_ID, 1)
+            except MorphoApiError as exc:
+                assert "not found" in str(exc)
+            else:
+                raise AssertionError("expected MorphoApiError")
+
+    def test_fetch_market_propagates_graphql_errors(self):
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(
+                {"errors": [{"message": "bad query"}]}
+            ).encode()
+            mock_open.return_value.__enter__.return_value = mock_resp
+
+            try:
+                fetch_market(MARKET_ID, 1)
+            except MorphoApiError as exc:
+                assert "bad query" in str(exc)
+            else:
+                raise AssertionError("expected MorphoApiError")
+
+    def test_fetch_market_handles_vault_without_public_allocator(self):
+        body = {
+            "data": {
+                "marketById": {
+                    "marketId": "0x" + MARKET_ID,
+                    "lltv": "0",
+                    "loanAsset": {
+                        "address": LOAN_TOKEN,
+                        "symbol": "USDC",
+                        "decimals": 6,
+                    },
+                    "collateralAsset": {
+                        "address": COLLATERAL_TOKEN,
+                        "symbol": "X",
+                        "decimals": 18,
+                    },
+                    "oracle": {"address": ORACLE},
+                    "irmAddress": IRM,
+                    "state": None,
+                    "supplyingVaults": [
+                        {
+                            "address": VAULT_ADDR,
+                            "symbol": "v",
+                            "name": "v",
+                            "asset": {"symbol": "USDC", "decimals": 6},
+                            "state": {"totalAssets": 0, "allocation": []},
+                            "publicAllocatorConfig": None,
+                        }
+                    ],
+                }
+            }
+        }
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(body).encode()
+            mock_open.return_value.__enter__.return_value = mock_resp
+
+            result = fetch_market(MARKET_ID, 1)
+
+        assert result.vaults[0].flow_cap is None
+        assert result.vaults[0].supply_assets == 0
+
+
+# ── meta-morpho subcommand + fetch_vault ──────────────────────────────
+
+
+def _v2_id_data_for(loan, collateral, oracle, irm, lltv):
+    """Encode an idData payload as Vault V2 does for MarketV1 caps."""
+    return (
+        "0x"
+        + encode(
+            [
+                "string",
+                "address",
+                "address",
+                "address",
+                "address",
+                "address",
+                "uint256",
+            ],
+            ["this/marketParams", loan, loan, collateral, oracle, irm, lltv],
+        ).hex()
+    )
+
+
+def _v2_response():
+    return {
+        "data": {
+            "vaultV2ByAddress": {
+                "address": "0xB885F6d448dA7E2C642Ec31190B629E40E87B069",
+                "name": "Yearn OG USDC",
+                "symbol": "yOG-USDC-V2",
+                "asset": {"address": LOAN_TOKEN, "symbol": "USDC", "decimals": 6},
+                "totalAssets": 857_498_945_341,
+                "idleAssets": 0,
+                "liquidity": 844_616_692_135,
+                "sharePrice": 1.018620,
+                "performanceFee": 0,
+                "performanceFeeRecipient": "0x" + "0" * 40,
+                "managementFee": 0,
+                "managementFeeRecipient": "0x" + "0" * 40,
+                "maxApy": 1.71,
+                "owner": {"address": "0x" + "1" * 40},
+                "curator": {"address": "0x" + "2" * 40},
+                "allocators": [{"allocator": {"address": "0x" + "3" * 40}}],
+                "sentinels": [],
+                "liquidityAdapter": {
+                    "__typename": "MorphoMarketV1Adapter",
+                    "address": "0x" + "5" * 40,
+                    "type": "MorphoMarketV1",
+                    "assets": 100,
+                },
+                "adapters": {
+                    "items": [
+                        {
+                            "__typename": "MorphoMarketV1Adapter",
+                            "address": "0x" + "5" * 40,
+                            "type": "MorphoMarketV1",
+                            "assets": 100,
+                        }
+                    ]
+                },
+                "caps": {
+                    "items": [
+                        {
+                            "id": "0xcap0",
+                            "idData": _v2_id_data_for(
+                                LOAN_TOKEN,
+                                COLLATERAL_TOKEN,
+                                ORACLE,
+                                IRM,
+                                915 * 10**15,
+                            ),
+                            "type": "MarketV1",
+                            "absoluteCap": 1_500_000_000_000,
+                            "relativeCap": "1000000000000000000",
+                            "allocation": 57,
+                        },
+                        {
+                            "id": "0xcap1",
+                            "idData": "0x",
+                            "type": "Adapter",
+                            "absoluteCap": 1000,
+                            "relativeCap": "1000000000000000000",
+                            "allocation": 0,
+                        },
+                    ]
+                },
+            }
+        }
+    }
+
+
+class TestMetaMorphoCommand:
+    def test_renders_v2_vault(self, tmp_path, monkeypatch):
+        _setup_provider(tmp_path, monkeypatch)
+        body = _v2_response()
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(body).encode()
+            mock_open.return_value.__enter__.return_value = mock_resp
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "market",
+                    "meta-morpho",
+                    "0xB885F6d448dA7E2C642Ec31190B629E40E87B069",
+                    "--chain",
+                    "1",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Morpho Vault V2 — Yearn OG USDC" in result.output
+        assert "Curator:" in result.output
+        assert "MorphoMarketV1" in result.output  # adapter type
+        assert "Morpho Blue market caps (1):" in result.output
+        # Decoded MarketParams
+        assert LOAN_TOKEN in result.output
+        assert COLLATERAL_TOKEN in result.output
+        assert "915000000000000000" in result.output  # lltv
+
+    def test_v2_market_filter_keeps_only_match(self, tmp_path, monkeypatch):
+        _setup_provider(tmp_path, monkeypatch)
+        body = _v2_response()
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(body).encode()
+            mock_open.return_value.__enter__.return_value = mock_resp
+
+            v = fetch_vault("0xB885F6d448dA7E2C642Ec31190B629E40E87B069", 1)
+
+        market_caps = [c for c in v.caps if c.cap_type == "MarketV1"]
+        assert len(market_caps) == 1
+        cap = market_caps[0]
+        assert cap.loan_token == LOAN_TOKEN
+        assert cap.collateral_token == COLLATERAL_TOKEN
+        assert cap.lltv == 915 * 10**15
+        assert cap.market_id is not None
+        assert cap.market_id.startswith("0x")
+        assert cap.absolute_cap == 1_500_000_000_000
+        assert cap.allocation == 57
+        assert cap.room == 1_500_000_000_000 - 57
+
+    def test_renders_v1_vault_when_v2_not_found(self, tmp_path, monkeypatch):
+        _setup_provider(tmp_path, monkeypatch)
+        v2_not_found = {
+            "data": {"vaultV2ByAddress": None},
+            "errors": [{"status": "NOT_FOUND"}],
+        }
+        v1_body = {
+            "data": {
+                "vaultByAddress": {
+                    "address": VAULT_ADDR,
+                    "name": "Test V1 Vault",
+                    "symbol": "tv1",
+                    "asset": {"address": LOAN_TOKEN, "symbol": "USDC", "decimals": 6},
+                    "state": {
+                        "totalAssets": 1_000_000_000,
+                        "fee": 10**17,
+                        "owner": "0x" + "1" * 40,
+                        "curator": "0x" + "2" * 40,
+                        "guardian": "0x" + "3" * 40,
+                        "feeRecipient": "0x" + "4" * 40,
+                        "allocation": [
+                            {
+                                "market": {
+                                    "marketId": "0x" + MARKET_ID,
+                                    "lltv": "915000000000000000",
+                                    "loanAsset": {"symbol": "USDC", "decimals": 6},
+                                    "collateralAsset": {"symbol": "WOUSD"},
+                                    "state": {
+                                        "supplyAssets": 1000,
+                                        "borrowAssets": 500,
+                                        "supplyApy": 0.03,
+                                    },
+                                },
+                                "supplyAssets": 0,
+                                "supplyCap": 1_500_000_000_000,
+                            }
+                        ],
+                    },
+                    "allocators": [{"address": PUBLIC_ALLOCATOR_ETH}],
+                    "publicAllocatorConfig": {
+                        "fee": 0,
+                        "admin": ADMIN_ADDR,
+                        "flowCaps": [
+                            {
+                                "market": {"marketId": "0x" + MARKET_ID},
+                                "maxIn": 750_000_000_000,
+                                "maxOut": 0,
+                            }
+                        ],
+                    },
+                }
+            }
+        }
+        responses = iter([v2_not_found, v1_body])
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+
+            def side_effect(*_args, **_kwargs):
+                resp = MagicMock()
+                resp.read.return_value = json.dumps(next(responses)).encode()
+                ctx_mgr = MagicMock()
+                ctx_mgr.__enter__.return_value = resp
+                return ctx_mgr
+
+            mock_open.side_effect = side_effect
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["market", "meta-morpho", VAULT_ADDR, "--chain", "1"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "MetaMorpho V1 — Test V1 Vault" in result.output
+        assert "[PublicAllocator]" in result.output
+        assert "Status:           enabled" in result.output
+
+    def test_unknown_vault_errors(self, tmp_path, monkeypatch):
+        _setup_provider(tmp_path, monkeypatch)
+        not_found = {
+            "data": {"vaultV2ByAddress": None},
+            "errors": [{"status": "NOT_FOUND"}],
+        }
+        v1_not_found = {
+            "data": {"vaultByAddress": None},
+            "errors": [{"status": "NOT_FOUND"}],
+        }
+        responses = iter([not_found, v1_not_found])
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+
+            def side_effect(*_args, **_kwargs):
+                resp = MagicMock()
+                resp.read.return_value = json.dumps(next(responses)).encode()
+                ctx_mgr = MagicMock()
+                ctx_mgr.__enter__.return_value = resp
+                return ctx_mgr
+
+            mock_open.side_effect = side_effect
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["market", "meta-morpho", VAULT_ADDR, "--chain", "1"],
+            )
+
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_json_output_v2(self, tmp_path, monkeypatch):
+        _setup_provider(tmp_path, monkeypatch)
+        body = _v2_response()
+        with patch("ipor_fusion.cli.morpho_api.urlopen") as mock_open:
+            mock_resp = MagicMock()
+            mock_resp.read.return_value = json.dumps(body).encode()
+            mock_open.return_value.__enter__.return_value = mock_resp
+
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "market",
+                    "meta-morpho",
+                    "0xB885F6d448dA7E2C642Ec31190B629E40E87B069",
+                    "--chain",
+                    "1",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["version"] == "v2"
+        assert data["name"] == "Yearn OG USDC"
+        market_caps = [c for c in data["caps"] if c["type"] == "MarketV1"]
+        assert len(market_caps) == 1
+        assert market_caps[0]["loan_token"] == LOAN_TOKEN
+        assert market_caps[0]["lltv"] == str(915 * 10**15)

--- a/tests/test_mcp_models.py
+++ b/tests/test_mcp_models.py
@@ -13,6 +13,8 @@ from pydantic import ValidationError
 from ipor_fusion.mcp.models import (
     Amount,
     ConfigShowResponse,
+    MetaMorphoVaultResponse,
+    MorphoBlueMarketResponse,
     Reconciliation,
     VaultInfoResponse,
     VaultListEntry,
@@ -248,6 +250,196 @@ class TestSimpleResponseContracts:
         VaultListEntry.model_validate(
             {"address": "0xA", "label": "x", "chain": "base", "chain_id": 8453}
         )
+
+    def test_morpho_blue_market_full_dict(self):
+        d = {
+            "market_id": "0x" + "ab" * 32,
+            "chain_id": 1,
+            "public_allocator": "0xPA",
+            "market_params": {
+                "loan_token": "0xLOAN",
+                "collateral_token": "0xCOL",
+                "oracle": "0xORA",
+                "irm": "0xIRM",
+                "lltv": "915000000000000000",
+            },
+            "state": {
+                "total_supply_assets": "1000",
+                "total_supply_shares": "1000000000000",
+                "total_borrow_assets": "900",
+                "total_borrow_shares": "900000000000",
+                "liquidity_assets": "100",
+                "fee_wad": "0",
+                "last_update": 1700000000,
+            },
+            "rates": {
+                "rate_per_second_wad": "1000000000",
+                "utilization": 0.9,
+                "borrow_apy": 0.032,
+                "supply_apy": 0.029,
+            },
+            "loan_asset": {
+                "address": "0xLOAN",
+                "symbol": "USDC",
+                "decimals": 6,
+            },
+            "collateral_asset": {
+                "address": "0xCOL",
+                "symbol": "WETH",
+                "decimals": 18,
+            },
+            "vaults": [
+                {
+                    "address": "0xVAULT",
+                    "name": "v",
+                    "symbol": "v",
+                    "asset": {"symbol": "USDC", "decimals": 6},
+                    "total_assets": "1000",
+                    "supply_assets": "0",
+                    "supply_cap": "500",
+                    "allocators": ["0xA"],
+                    "public_allocator_config": {
+                        "fee_wei": "0",
+                        "max_in": "100",
+                        "max_out": "0",
+                        "admin": "0xADMIN",
+                    },
+                }
+            ],
+        }
+        result = MorphoBlueMarketResponse.model_validate(d)
+        assert result.market_id.startswith("0x")
+        assert result.vaults is not None
+        assert result.vaults[0].public_allocator_config is not None
+
+    def test_morpho_blue_market_minimal_no_api(self):
+        """no_api branch: no loan_asset / collateral_asset / vaults."""
+        d = {
+            "market_id": "0xab",
+            "chain_id": 1,
+            "market_params": {
+                "loan_token": "0xL",
+                "collateral_token": "0xC",
+                "oracle": "0xO",
+                "irm": "0xI",
+                "lltv": "0",
+            },
+            "state": {
+                "total_supply_assets": "0",
+                "total_supply_shares": "0",
+                "total_borrow_assets": "0",
+                "total_borrow_shares": "0",
+                "liquidity_assets": "0",
+                "fee_wad": "0",
+                "last_update": 0,
+            },
+            "rates": {
+                "rate_per_second_wad": "0",
+                "utilization": 0.0,
+                "borrow_apy": 0.0,
+                "supply_apy": 0.0,
+            },
+        }
+        MorphoBlueMarketResponse.model_validate(d)
+
+    def test_morpho_blue_unknown_field_rejected(self):
+        d = {
+            "market_id": "0xab",
+            "chain_id": 1,
+            "market_params": {
+                "loan_token": "0xL",
+                "collateral_token": "0xC",
+                "oracle": "0xO",
+                "irm": "0xI",
+                "lltv": "0",
+            },
+            "state": {
+                "total_supply_assets": "0",
+                "total_supply_shares": "0",
+                "total_borrow_assets": "0",
+                "total_borrow_shares": "0",
+                "liquidity_assets": "0",
+                "fee_wad": "0",
+                "last_update": 0,
+            },
+            "rates": {
+                "rate_per_second_wad": "0",
+                "utilization": 0.0,
+                "borrow_apy": 0.0,
+                "supply_apy": 0.0,
+            },
+            "drift": "no",
+        }
+        with pytest.raises(ValidationError):
+            MorphoBlueMarketResponse.model_validate(d)
+
+    def test_meta_morpho_v2_validates(self):
+        d = {
+            "version": "v2",
+            "chain_id": 1,
+            "address": "0xVAULT",
+            "name": "v",
+            "symbol": "v",
+            "asset": {"address": "0xL", "symbol": "USDC", "decimals": 6},
+            "total_assets": "1000",
+            "idle_assets": "0",
+            "liquidity": "1000",
+            "share_price": 1.0,
+            "max_apy": 0.05,
+            "performance_fee": 0.0,
+            "performance_fee_recipient": "0xPF",
+            "management_fee": 0.0,
+            "management_fee_recipient": "0xMF",
+            "owner": "0xOWNER",
+            "curator": "0xCUR",
+            "allocators": ["0xA"],
+            "sentinels": [],
+            "liquidity_adapter": None,
+            "adapters": [],
+            "caps": [],
+        }
+        result = MetaMorphoVaultResponse.model_validate(d)
+        assert result.version == "v2"
+        assert result.fee_wad is None  # v1-only stays unset
+
+    def test_meta_morpho_v1_validates(self):
+        d = {
+            "version": "v1",
+            "chain_id": 1,
+            "address": "0xVAULT",
+            "name": "v",
+            "symbol": "v",
+            "asset": {"address": "0xL", "symbol": "USDC", "decimals": 6},
+            "total_assets": "1000",
+            "fee_wad": "100000000000000000",
+            "owner": "0xOWNER",
+            "curator": "0xCUR",
+            "guardian": "0xGUARD",
+            "fee_recipient": "0xFR",
+            "allocators": ["0xA"],
+            "public_allocator": None,
+            "allocations": [],
+        }
+        result = MetaMorphoVaultResponse.model_validate(d)
+        assert result.version == "v1"
+        assert result.adapters is None  # v2-only stays unset
+
+    def test_meta_morpho_unknown_field_rejected(self):
+        d = {
+            "version": "v1",
+            "chain_id": 1,
+            "address": "0xVAULT",
+            "name": "v",
+            "symbol": "v",
+            "asset": {},
+            "total_assets": "0",
+            "owner": "0x",
+            "curator": "0x",
+            "allocators": [],
+            "drift": "no",
+        }
+        with pytest.raises(ValidationError):
+            MetaMorphoVaultResponse.model_validate(d)
 
     def test_reconciliation_with_no_usd_in_implied_market_total(self):
         """implied_market_total is the only Amount in reconciliation_json that

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -142,3 +142,315 @@ class TestVaultRemove:
     def test_remove_missing(self, _):
         result = vault_remove(address="0xNONEXISTENT")
         assert "not found" in result.message.lower()
+
+
+# ── market tools ──────────────────────────────────────────────────────
+
+
+from ipor_fusion.cli.morpho_api import (  # noqa: E402  pylint: disable=wrong-import-position
+    MorphoApiError,
+    MorphoApiMarket,
+    VaultAllocation,
+    VaultFlowCap,
+    VaultV1Info,
+    VaultV1MarketAllocation,
+    VaultV2Adapter,
+    VaultV2Cap,
+    VaultV2Info,
+)
+from ipor_fusion.mcp.server import (  # noqa: E402  pylint: disable=wrong-import-position
+    market_meta_morpho,
+    market_morpho_blue,
+)
+from ipor_fusion.readers.morpho import (  # noqa: E402  pylint: disable=wrong-import-position
+    MorphoMarket,
+    MorphoMarketParams,
+    MorphoMarketRates,
+)
+
+_MARKET_ID = "ad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc"
+_LOAN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+_COLLAT = "0xD2af830E8CBdFed6CC11Bab697bB25496ed6FA62"
+_ORACLE = "0x7C65985C35181D51eF7571FA40211B57659B7d80"
+_IRM = "0x870Ac11D48B15db9a138Cf899d20F13F79Ba00BC"
+_VAULT = "0xf9bDdD4A9b3a45F980E11Fdde96E16364DDBec49"
+
+
+def _stub_reader_instance():
+    reader = MagicMock()
+    reader.market_params.return_value = MorphoMarketParams(
+        loan_token=_LOAN,
+        collateral_token=_COLLAT,
+        oracle=_ORACLE,
+        irm=_IRM,
+        lltv=915 * 10**15,
+    )
+    reader.market.return_value = MorphoMarket(
+        total_supply_assets=1_008_277,
+        total_supply_shares=1_008_277_000_000,
+        total_borrow_assets=908_170,
+        total_borrow_shares=908_170_000_000,
+        last_update=1700000000,
+        fee=0,
+    )
+    reader.rates_from.return_value = MorphoMarketRates(
+        rate_per_second_wad=10**9,
+        utilization=0.9,
+        borrow_apy=0.032,
+        supply_apy=0.029,
+    )
+    return reader
+
+
+def _api_market():
+    return MorphoApiMarket(
+        market_id="0x" + _MARKET_ID,
+        lltv=915 * 10**15,
+        loan_token=_LOAN,
+        loan_symbol="USDC",
+        loan_decimals=6,
+        collateral_token=_COLLAT,
+        collateral_symbol="WOUSD",
+        collateral_decimals=18,
+        oracle=_ORACLE,
+        irm=_IRM,
+        supply_assets=1_008_277,
+        borrow_assets=908_170,
+        liquidity_assets=100_107,
+        utilization=0.9,
+        supply_apy=0.029,
+        borrow_apy=0.032,
+        fee_wad=0,
+        timestamp=1700000000,
+        vaults=[
+            VaultAllocation(
+                vault_address=_VAULT,
+                vault_name="Yearn OG USDC",
+                vault_symbol="ymvOG-USDC",
+                asset_symbol="USDC",
+                asset_decimals=6,
+                total_assets=2_000_000_000,
+                supply_assets=0,
+                supply_cap=1_500_000_000_000,
+                allocators=[_VAULT],
+                flow_cap=VaultFlowCap(
+                    fee_wei=10**15,
+                    max_in=750_000_000_000,
+                    max_out=250_000_000_000,
+                    admin=_VAULT,
+                ),
+            )
+        ],
+    )
+
+
+class TestMarketMorphoBlue:
+    @patch("ipor_fusion.mcp.server.fetch_market")
+    @patch("ipor_fusion.mcp.server.MorphoReader")
+    @patch("ipor_fusion.mcp.server.Web3Context")
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_returns_market_state_and_vaults(
+        self, _load, mock_ctx_cls, mock_reader_cls, mock_fetch
+    ):
+        mock_ctx_cls.from_url.return_value = MagicMock()
+        mock_reader_cls.return_value = _stub_reader_instance()
+        mock_fetch.return_value = _api_market()
+
+        result = market_morpho_blue(market_id=_MARKET_ID, chain_id=1)
+
+        assert result.market_id == "0x" + _MARKET_ID
+        assert result.chain_id == 1
+        assert result.public_allocator is not None  # singleton on Ethereum
+        assert result.market_params.loan_token == _LOAN
+        assert result.market_params.lltv == str(915 * 10**15)
+        assert result.state.liquidity_assets == "100107"
+        assert result.rates.utilization == 0.9
+        assert result.api_error is None
+        assert result.loan_asset is not None
+        assert result.loan_asset.symbol == "USDC"
+        assert result.vaults is not None and len(result.vaults) == 1
+        vault = result.vaults[0]
+        assert vault.public_allocator_config is not None
+        assert vault.public_allocator_config.max_in == "750000000000"
+
+    @patch("ipor_fusion.mcp.server.fetch_market")
+    @patch("ipor_fusion.mcp.server.MorphoReader")
+    @patch("ipor_fusion.mcp.server.Web3Context")
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_no_api_skips_fetch(self, _load, mock_ctx_cls, mock_reader_cls, mock_fetch):
+        mock_ctx_cls.from_url.return_value = MagicMock()
+        mock_reader_cls.return_value = _stub_reader_instance()
+
+        result = market_morpho_blue(market_id=_MARKET_ID, chain_id=1, no_api=True)
+
+        assert mock_fetch.call_count == 0
+        assert result.vaults is None
+        assert result.loan_asset is None
+        assert result.api_error is None
+
+    @patch("ipor_fusion.mcp.server.fetch_market", side_effect=MorphoApiError("down"))
+    @patch("ipor_fusion.mcp.server.MorphoReader")
+    @patch("ipor_fusion.mcp.server.Web3Context")
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_api_error_surfaces_in_response(
+        self, _load, mock_ctx_cls, mock_reader_cls, _fetch
+    ):
+        mock_ctx_cls.from_url.return_value = MagicMock()
+        mock_reader_cls.return_value = _stub_reader_instance()
+
+        result = market_morpho_blue(market_id=_MARKET_ID, chain_id=1)
+
+        assert result.api_error == "down"
+        assert result.vaults is None  # API didn't populate
+        # On-chain rates still returned
+        assert result.rates.utilization == 0.9
+
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_invalid_market_id_rejected(self, _load):
+        try:
+            market_morpho_blue(market_id="0xdead", chain_id=1)
+        except ValueError as exc:
+            assert "invalid Morpho market ID" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_empty_config(),
+    )
+    def test_missing_provider_errors(self, _load):
+        try:
+            market_morpho_blue(market_id=_MARKET_ID, chain_id=1)
+        except ValueError as exc:
+            assert "No provider for chain" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+def _v1_info():
+    return VaultV1Info(
+        address=_VAULT,
+        name="Test V1",
+        symbol="tv1",
+        asset_address=_LOAN,
+        asset_symbol="USDC",
+        asset_decimals=6,
+        total_assets=1_000_000_000,
+        fee_wad=10**17,
+        owner="0x" + "1" * 40,
+        curator="0x" + "2" * 40,
+        guardian="0x" + "3" * 40,
+        fee_recipient="0x" + "4" * 40,
+        allocators=[_VAULT],
+        allocations=[
+            VaultV1MarketAllocation(
+                market_id="0x" + _MARKET_ID,
+                lltv=915 * 10**15,
+                loan_symbol="USDC",
+                loan_decimals=6,
+                collateral_symbol="WOUSD",
+                market_supply_assets=1_000,
+                market_borrow_assets=500,
+                market_supply_apy=0.03,
+                supply_assets=0,
+                supply_cap=1_500_000_000_000,
+            )
+        ],
+        public_allocator=VaultFlowCap(fee_wei=0, max_in=0, max_out=0, admin=_VAULT),
+        public_allocator_flow_caps={"0x" + _MARKET_ID: (750_000_000_000, 0)},
+    )
+
+
+def _v2_info():
+    cap = VaultV2Cap(
+        cap_id="0xcap0",
+        cap_type="MarketV1",
+        id_data="0x",
+        absolute_cap=1_500_000_000_000,
+        relative_cap_wad=10**18,
+        allocation=57,
+        market_id="0x" + _MARKET_ID,
+        loan_token=_LOAN,
+        collateral_token=_COLLAT,
+        oracle=_ORACLE,
+        irm=_IRM,
+        lltv=915 * 10**15,
+    )
+    adapter = VaultV2Adapter(
+        address="0x" + "5" * 40,
+        adapter_type="MorphoMarketV1",
+        assets=100,
+        inner_vault=None,
+    )
+    return VaultV2Info(
+        address=_VAULT,
+        name="Yearn OG USDC",
+        symbol="yOG-USDC-V2",
+        asset_address=_LOAN,
+        asset_symbol="USDC",
+        asset_decimals=6,
+        total_assets=857_498_945_341,
+        idle_assets=0,
+        liquidity=844_616_692_135,
+        share_price=1.018620,
+        max_apy=1.71,
+        performance_fee=0.0,
+        performance_fee_recipient="0x" + "0" * 40,
+        management_fee=0.0,
+        management_fee_recipient="0x" + "0" * 40,
+        owner="0x" + "1" * 40,
+        curator="0x" + "2" * 40,
+        allocators=["0x" + "3" * 40],
+        sentinels=[],
+        liquidity_adapter=adapter,
+        adapters=[adapter],
+        caps=[cap],
+    )
+
+
+class TestMarketMetaMorpho:
+    @patch("ipor_fusion.mcp.server.fetch_vault", return_value=_v2_info())
+    def test_returns_v2_vault(self, _fetch):
+        result = market_meta_morpho(vault_address=_VAULT, chain_id=1)
+        assert result.version == "v2"
+        assert result.name == "Yearn OG USDC"
+        assert result.caps is not None and len(result.caps) == 1
+        assert result.caps[0]["loan_token"] == _LOAN
+        # v1-only fields should be None
+        assert result.fee_wad is None
+        assert result.allocations is None
+
+    @patch("ipor_fusion.mcp.server.fetch_vault", return_value=_v1_info())
+    def test_returns_v1_vault(self, _fetch):
+        result = market_meta_morpho(vault_address=_VAULT, chain_id=1)
+        assert result.version == "v1"
+        assert result.name == "Test V1"
+        assert result.fee_wad == str(10**17)
+        assert result.allocations is not None and len(result.allocations) == 1
+        # v2-only fields should be None
+        assert result.caps is None
+        assert result.adapters is None
+
+    @patch(
+        "ipor_fusion.mcp.server.fetch_vault",
+        side_effect=MorphoApiError("not found"),
+    )
+    def test_unknown_vault_errors(self, _fetch):
+        try:
+            market_meta_morpho(vault_address=_VAULT, chain_id=1)
+        except ValueError as exc:
+            assert "not found" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")

--- a/tests/test_reader_encoding.py
+++ b/tests/test_reader_encoding.py
@@ -8,6 +8,7 @@ from web3 import Web3
 from ipor_fusion.readers.morpho import (
     MorphoReader,
     MorphoMarket,
+    MorphoMarketRates,
     MorphoPosition,
     MorphoMarketParams,
     MorphoPositionBreakdown,
@@ -317,6 +318,72 @@ class TestMorphoReaderPositionBreakdown:
         assert result.borrow_assets == 0
         assert result.supply_assets == 0
         assert result.collateral == 0
+
+
+class TestMorphoReaderRates:
+    def test_rates_computes_apy_and_utilization(self):
+        reader, ctx = _make_reader(MorphoReader)
+        # market(): 90% utilization, 0 protocol fee
+        market_raw = encode(
+            ["uint128", "uint128", "uint128", "uint128", "uint128", "uint128"],
+            [1_000_000, 1_000_000, 900_000, 900_000, 1700000000, 0],
+        )
+        params_raw = encode(
+            ["address", "address", "address", "address", "uint256"],
+            [TOKEN_A, TOKEN_B, ORACLE, IRM, 860000000000000000],
+        )
+        # IRM rate = 1e9 wei/sec → ~3.27% borrow APY
+        # (1e9 / 1e18) * 31_536_000 = 0.031536 → exp(...)-1 ≈ 0.03204
+        rate_raw = encode(["uint256"], [10**9])
+        ctx.call.side_effect = [market_raw, params_raw, rate_raw]
+
+        result = reader.rates(MARKET_ID)
+
+        assert isinstance(result, MorphoMarketRates)
+        assert result.rate_per_second_wad == 10**9
+        assert result.utilization == 0.9
+        assert abs(result.borrow_apy - 0.032063) < 1e-4
+        # supply_apy = borrow_apy * util * (1 - fee) = borrow_apy * 0.9
+        assert abs(result.supply_apy - result.borrow_apy * 0.9) < 1e-9
+
+    def test_rates_handles_empty_market(self):
+        reader, ctx = _make_reader(MorphoReader)
+        market_raw = encode(
+            ["uint128", "uint128", "uint128", "uint128", "uint128", "uint128"],
+            [0, 0, 0, 0, 0, 0],
+        )
+        params_raw = encode(
+            ["address", "address", "address", "address", "uint256"],
+            [TOKEN_A, TOKEN_B, ORACLE, IRM, 860000000000000000],
+        )
+        rate_raw = encode(["uint256"], [0])
+        ctx.call.side_effect = [market_raw, params_raw, rate_raw]
+
+        result = reader.rates(MARKET_ID)
+
+        assert result.utilization == 0.0
+        assert result.borrow_apy == 0.0
+        assert result.supply_apy == 0.0
+
+    def test_rates_applies_protocol_fee_to_supply_apy(self):
+        reader, ctx = _make_reader(MorphoReader)
+        # 10% protocol fee — supply APY should be reduced by 10%
+        fee_wad = 10**17  # 0.1 * 1e18
+        market_raw = encode(
+            ["uint128", "uint128", "uint128", "uint128", "uint128", "uint128"],
+            [1_000_000, 1_000_000, 1_000_000, 1_000_000, 1700000000, fee_wad],
+        )
+        params_raw = encode(
+            ["address", "address", "address", "address", "uint256"],
+            [TOKEN_A, TOKEN_B, ORACLE, IRM, 860000000000000000],
+        )
+        rate_raw = encode(["uint256"], [10**9])
+        ctx.call.side_effect = [market_raw, params_raw, rate_raw]
+
+        result = reader.rates(MARKET_ID)
+
+        # supply_apy = borrow_apy * util(=1.0) * 0.9
+        assert abs(result.supply_apy - result.borrow_apy * 0.9) < 1e-12
 
 
 # ── Compound V3 ────────────────────────────────────────────────────────

--- a/tests/test_vault_dep_graph.py
+++ b/tests/test_vault_dep_graph.py
@@ -1,9 +1,13 @@
 """Tests for dependency balance graph analysis."""
 
 from ipor_fusion.cli.vault_dep_graph import (
+    NO_BALANCE_FUSE_MARKETS,
     compute_update_groups,
     compute_update_reach,
+    find_markets_missing_erc20_dependency,
+    find_orphan_fuse_markets,
 )
+from ipor_fusion.market_ids import IporFusionMarkets
 
 
 class TestComputeUpdateReach:
@@ -97,3 +101,112 @@ class TestComputeUpdateGroups:
         assert reach[morpho] == {erc20, erc4626}
         assert reach[erc4626] == {erc20, morpho}
         assert reach[flash] == {erc20}
+
+
+class TestFindOrphanFuseMarkets:
+    def test_empty_inputs(self):
+        assert not find_orphan_fuse_markets({}, set())
+
+    def test_all_markets_covered(self):
+        fuse_markets = {"0xfuse1": IporFusionMarkets.MORPHO}
+        balance_markets = {IporFusionMarkets.MORPHO}
+        assert not find_orphan_fuse_markets(fuse_markets, balance_markets)
+
+    def test_morpho_action_fuse_without_balance_fuse(self):
+        """The misconfiguration the CLI must catch: Morpho action fuse but no
+        Morpho balance fuse, so positions opened via the fuse silently drop
+        out of totalAssets."""
+        fuse_markets = {
+            "0xMorphoSupply": IporFusionMarkets.MORPHO,
+            "0xMorphoBorrow": IporFusionMarkets.MORPHO,
+        }
+        balance_markets = {IporFusionMarkets.ERC20_VAULT_BALANCE}
+        orphans = find_orphan_fuse_markets(fuse_markets, balance_markets)
+        assert orphans == {
+            IporFusionMarkets.MORPHO: ["0xMorphoSupply", "0xMorphoBorrow"]
+        }
+
+    def test_flash_loan_market_excluded(self):
+        """Flash loans intentionally have no balance fuse — must not flag."""
+        fuse_markets = {"0xFlashLoan": IporFusionMarkets.MORPHO_FLASH_LOAN}
+        assert not find_orphan_fuse_markets(fuse_markets, set())
+
+    def test_swap_markets_excluded(self):
+        fuse_markets = {
+            "0xUniV2": IporFusionMarkets.UNISWAP_SWAP_V2,
+            "0xUniV3": IporFusionMarkets.UNISWAP_SWAP_V3,
+            "0xUTS": IporFusionMarkets.UNIVERSAL_TOKEN_SWAPPER,
+        }
+        assert not find_orphan_fuse_markets(fuse_markets, set())
+
+    def test_mixed_orphan_and_valid(self):
+        fuse_markets = {
+            "0xAaveSupply": IporFusionMarkets.AAVE_V3,
+            "0xMorphoSupply": IporFusionMarkets.MORPHO,
+            "0xFlashLoan": IporFusionMarkets.MORPHO_FLASH_LOAN,
+        }
+        balance_markets = {IporFusionMarkets.AAVE_V3}
+        assert find_orphan_fuse_markets(fuse_markets, balance_markets) == {
+            IporFusionMarkets.MORPHO: ["0xMorphoSupply"]
+        }
+
+    def test_unknown_market_id_flagged(self):
+        """An unknown (newly added) market without balance fuse is still an
+        orphan — fail loudly so the allowlist gets updated explicitly."""
+        fuse_markets = {"0xWeird": 9999}
+        assert find_orphan_fuse_markets(fuse_markets, set()) == {9999: ["0xWeird"]}
+
+    def test_no_balance_fuse_markets_constant(self):
+        """Sanity-check the allowlist contains the well-known flow-through
+        markets. Adding new entries here is allowed; removing is a regression."""
+        assert IporFusionMarkets.MORPHO_FLASH_LOAN in NO_BALANCE_FUSE_MARKETS
+        assert IporFusionMarkets.UNIVERSAL_TOKEN_SWAPPER in NO_BALANCE_FUSE_MARKETS
+
+
+class TestFindMarketsMissingErc20Dependency:
+    """The misconfiguration mirrors what we found on a real Base vault:
+    MORPHO_LIQUIDITY_IN_MARKETS had a balance fuse but no edge to
+    ERC20_VAULT_BALANCE in the dep graph, so updateMarketsBalances(41)
+    didn't refresh ERC20 cache."""
+
+    erc20 = IporFusionMarkets.ERC20_VAULT_BALANCE
+    morpho_lim = 41
+    euler = IporFusionMarkets.EULER_V2
+
+    def test_empty_inputs(self):
+        assert not find_markets_missing_erc20_dependency(set(), {})
+
+    def test_market_with_correct_dependency(self):
+        result = find_markets_missing_erc20_dependency(
+            {self.euler}, {self.euler: [self.erc20]}
+        )
+        assert not result
+
+    def test_market_missing_erc20_dependency(self):
+        """The actual user-reported case."""
+        result = find_markets_missing_erc20_dependency(
+            {self.morpho_lim}, dependency_graph={}
+        )
+        assert result == [self.morpho_lim]
+
+    def test_market_with_other_deps_but_not_erc20(self):
+        result = find_markets_missing_erc20_dependency(
+            {self.morpho_lim}, {self.morpho_lim: [self.euler]}
+        )
+        assert result == [self.morpho_lim]
+
+    def test_erc20_market_itself_excluded(self):
+        result = find_markets_missing_erc20_dependency({self.erc20}, {})
+        assert not result
+
+    def test_zero_balance_sentinel_excluded(self):
+        zero_balance = 2**256 - 1
+        result = find_markets_missing_erc20_dependency({zero_balance}, {})
+        assert not result
+
+    def test_mixed_correct_and_missing(self):
+        result = find_markets_missing_erc20_dependency(
+            {self.euler, self.morpho_lim, self.erc20},
+            {self.euler: [self.erc20]},
+        )
+        assert result == [self.morpho_lim]


### PR DESCRIPTION
Misconfiguration detection in fusion vault info:
- Orphan action fuses: flag fuses whose MARKET_ID() has no balance fuse (positions silently bypass totalAssets). Allowlist for flow-through markets (flash loans, swaps, harvest) avoids false positives.
- Missing ERC20 dependency: flag balance-fuse markets whose dep graph omits ERC20_VAULT_BALANCE — updateMarketsBalances() won't refresh the ERC20 cache, causing totalAssets drift.

UX improvements:
- Unified Fuses + Instant Withdrawal Fuses tables: same renderer, same columns, dedupe by address with N unique / M registrations in the header, Substrates count column from market substrates.
- uint256.max sentinel rendered short instead of 78 digits.

New CLI/MCP capability:
- fusion market morpho-blue <id> + matching MCP tools fetch on-chain Morpho Blue market data and supplying vaults via blue-api.morpho.org.
- Morpho reader gains supply/borrow position breakdown helpers.