### PR TITLE
feat(health): flag Morpho collateral tokens with no price feed

### DIFF
--- a/src/ipor_fusion/cli/vault_fetcher.py
+++ b/src/ipor_fusion/cli/vault_fetcher.py
@@ -105,6 +105,12 @@ class _VaultData:
     # vault's PriceOracleMiddleware. Missing keys mean the oracle has no source
     # configured for that token.
     token_prices_usd: dict[str, float] | None = None
+    # Price-feed *source* address per breakdown token, keyed by lowercase
+    # address. A zero-address source means the PriceOracleMiddleware has no feed
+    # configured for that token; used to flag unpriceable Morpho collateral
+    # (a permissionless-supplyCollateral griefing/DoS vector). Tokens whose
+    # source read failed transiently are absent (not treated as missing).
+    asset_price_sources: dict[str, str] | None = None
     # MARKET_ID() reported by each registered action fuse. Keyed by checksummed
     # fuse address. Fuses that don't expose MARKET_ID() (or whose call reverts)
     # are absent from the dict — used to detect orphan markets (action fuses
@@ -374,6 +380,35 @@ def _fetch_breakdown_token_prices(
     return prices or None
 
 
+def _fetch_asset_price_sources(
+    pool: ThreadPoolExecutor,
+    oracle: PriceOracleMiddleware,
+    addresses: set[ChecksumAddress],
+) -> dict[str, str] | None:
+    """Fetch the configured price-feed source per breakdown token in parallel.
+
+    Returns a dict keyed by lowercase token address → source address (hex). A
+    zero-address source means the oracle has no feed configured for that token;
+    the health check flags Morpho collateral tokens in that state (see
+    ``_compute_unpriceable_collateral_criticals``). ``getSourceOfAssetPrice``
+    does not revert on a missing source, so a token is omitted only when the
+    read fails transiently — such tokens are not mistaken for a missing feed.
+    """
+    if not addresses:
+        return None
+    futures = {
+        addr: pool.submit(
+            _safe_call, lambda a=addr: oracle.get_source_of_asset_price(a).call()
+        )
+        for addr in addresses
+    }
+    sources: dict[str, str] = {}
+    for addr, fut in futures.items():
+        if (source := fut.result()) is not None:
+            sources[addr.lower()] = str(source)
+    return sources or None
+
+
 def _fetch_vault_data(
     ctx: Web3Context,
     plasma_vault: PlasmaVault,
@@ -485,15 +520,20 @@ def _fetch_vault_data(
             aave_positions = _fetch_aave_positions(
                 ctx, pool, vault_addr, chain_id, market_substrates
             )
+            breakdown_addrs = _collect_breakdown_token_addresses(
+                morpho_positions, aave_positions
+            )
             token_prices_usd = _fetch_breakdown_token_prices(
-                pool,
-                oracle,
-                _collect_breakdown_token_addresses(morpho_positions, aave_positions),
+                pool, oracle, breakdown_addrs
+            )
+            asset_price_sources = _fetch_asset_price_sources(
+                pool, oracle, breakdown_addrs
             )
         else:
             morpho_positions = None
             aave_positions = None
             token_prices_usd = None
+            asset_price_sources = None
             market_substrates = {}
 
         return _VaultData(
@@ -523,6 +563,7 @@ def _fetch_vault_data(
             morpho_positions=morpho_positions,
             aave_positions=aave_positions,
             token_prices_usd=token_prices_usd,
+            asset_price_sources=asset_price_sources,
             fuse_markets=fuse_markets or None,
             market_substrates=market_substrates or None,
         )

--- a/src/ipor_fusion/cli/vault_health.py
+++ b/src/ipor_fusion/cli/vault_health.py
@@ -503,6 +503,48 @@ def _compute_missing_erc20_dep_criticals(data: _VaultData) -> list[str]:
     ]
 
 
+def _compute_unpriceable_collateral_criticals(data: _VaultData) -> list[str]:
+    """Flag Morpho collateral tokens that have no price feed in the middleware.
+
+    ``MorphoBalanceFuse.balanceOf()`` iterates every whitelisted Morpho market
+    and prices the collateral leg whenever it is non-zero. Because Morpho's
+    ``supplyCollateral`` is permissionless in ``onBehalf``, anyone can push
+    collateral onto the vault's position in a whitelisted market; if that
+    market's collateral token has no feed, ``getAssetPrice`` reverts,
+    ``balanceOf`` reverts, and ``totalAssets`` (deposits/withdrawals/
+    reconciliation) is bricked.
+
+    The check keys off whitelisted substrates (via the per-market breakdown),
+    not current positions, so it catches the exposure *before* it is exploited.
+    A zero-address feed source means "no feed"; tokens whose source read failed
+    transiently are absent from ``asset_price_sources`` and are not flagged.
+    """
+    if not data.morpho_positions or data.asset_price_sources is None:
+        return []
+    sources = data.asset_price_sources
+    lines: list[str] = []
+    seen: set[str] = set()
+    for market_id, breakdowns in data.morpho_positions.items():
+        for pb in breakdowns:
+            key = pb.collateral_token.lower()
+            if key in seen:
+                continue
+            source = sources.get(key)
+            if source is None:
+                continue
+            if int(source, 16) == 0:
+                seen.add(key)
+                lines.append(
+                    f"CRITICAL — Morpho market {market_id}: collateral token "
+                    f"{pb.collateral_token} has no price feed in the "
+                    f"PriceOracleMiddleware — anyone can supplyCollateral "
+                    f"onBehalf of the vault to make MorphoBalanceFuse."
+                    f"balanceOf() revert, bricking totalAssets "
+                    f"(deposits/withdrawals/reconciliation)"
+                )
+    return lines
+
+
 def _compute_health_check(  # noqa: C901
     data: _VaultData,
     bf_totals: _BalanceFuseTotals,
@@ -517,6 +559,7 @@ def _compute_health_check(  # noqa: C901
 
     result.criticals.extend(_compute_orphan_fuse_criticals(data))
     result.criticals.extend(_compute_missing_erc20_dep_criticals(data))
+    result.criticals.extend(_compute_unpriceable_collateral_criticals(data))
 
     # Lending health warnings
     if data.lending_health and data.lending_health.has_lending_positions:

--- a/tests/test_cli_health_unpriceable_collateral.py
+++ b/tests/test_cli_health_unpriceable_collateral.py
@@ -1,0 +1,76 @@
+"""Unit tests for the unpriceable-Morpho-collateral health critical.
+
+Exercises the pure helper ``_compute_unpriceable_collateral_criticals`` with
+duck-typed fixtures — it only reads ``data.morpho_positions`` (a dict of
+market_id -> breakdowns with a ``collateral_token``) and
+``data.asset_price_sources`` (lowercase token address -> feed source), so no
+chain access or full ``_VaultData`` construction is needed.
+"""
+
+from types import SimpleNamespace
+
+from ipor_fusion.cli.vault_health import _compute_unpriceable_collateral_criticals
+
+_FEED = "0x1111111111111111111111111111111111111111"
+_ZERO = "0x0000000000000000000000000000000000000000"
+_CB_BTC = "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+_WETH = "0x4200000000000000000000000000000000000006"
+
+
+def _breakdown(collateral_token: str) -> SimpleNamespace:
+    return SimpleNamespace(collateral_token=collateral_token)
+
+
+def _data(morpho_positions, asset_price_sources) -> SimpleNamespace:
+    return SimpleNamespace(
+        morpho_positions=morpho_positions,
+        asset_price_sources=asset_price_sources,
+    )
+
+
+def test_flags_collateral_without_feed():
+    data = _data({14: [_breakdown(_CB_BTC)]}, {_CB_BTC.lower(): _ZERO})
+    criticals = _compute_unpriceable_collateral_criticals(data)
+    assert len(criticals) == 1
+    assert _CB_BTC in criticals[0]
+    assert "supplyCollateral" in criticals[0]
+
+
+def test_no_flag_when_feed_present():
+    data = _data({14: [_breakdown(_WETH)]}, {_WETH.lower(): _FEED})
+    assert _compute_unpriceable_collateral_criticals(data) == []
+
+
+def test_skips_when_source_unknown():
+    # Transient read failure -> token omitted from sources -> not a false alarm.
+    data = _data({14: [_breakdown(_CB_BTC)]}, {})
+    assert _compute_unpriceable_collateral_criticals(data) == []
+
+
+def test_dedupes_same_collateral_across_markets():
+    data = _data(
+        {14: [_breakdown(_CB_BTC)], 15: [_breakdown(_CB_BTC)]},
+        {_CB_BTC.lower(): _ZERO},
+    )
+    assert len(_compute_unpriceable_collateral_criticals(data)) == 1
+
+
+def test_mixed_feeds_flag_only_missing():
+    data = _data(
+        {14: [_breakdown(_WETH), _breakdown(_CB_BTC)]},
+        {_WETH.lower(): _FEED, _CB_BTC.lower(): _ZERO},
+    )
+    criticals = _compute_unpriceable_collateral_criticals(data)
+    assert len(criticals) == 1
+    assert _CB_BTC in criticals[0]
+    assert _WETH not in criticals[0]
+
+
+def test_empty_when_no_morpho_positions_or_sources():
+    assert _compute_unpriceable_collateral_criticals(_data(None, {_ZERO: _ZERO})) == []
+    assert (
+        _compute_unpriceable_collateral_criticals(
+            _data({14: [_breakdown(_CB_BTC)]}, None)
+        )
+        == []
+    )


### PR DESCRIPTION
MorphoBalanceFuse.balanceOf() prices the collateral leg of every whitelisted market; Morpho supplyCollateral is permissionless in onBehalf, so anyone can push collateral onto the vault and, if that collateral token has no middleware feed, brick totalAssets. Flag it as a CRITICAL (keyed off whitelisted substrates, pre-exploitation).