### PR TITLE
Balance fuses that price via the IPOR PriceOracleMiddleware revert

### DIFF
--- a/src/ipor_fusion/cli/vault_fetcher.py
+++ b/src/ipor_fusion/cli/vault_fetcher.py
@@ -24,6 +24,7 @@ from ipor_fusion.core.erc20 import ERC20
 from ipor_fusion.core.oracle import PriceOracleMiddleware
 from ipor_fusion.core.plasma_vault import PlasmaVault
 from ipor_fusion.core.withdraw_manager import AccountRequest, WithdrawManager
+from ipor_fusion.market_ids import IporFusionMarkets
 from ipor_fusion.readers.aave_v3 import AaveV3PositionBreakdown, AaveV3Reader
 from ipor_fusion.readers.lending_health import (
     AAVE_V3_MARKET_IDS,
@@ -53,6 +54,23 @@ class _WithdrawManagerData:
     shares_to_release: int
     last_release_funds_timestamp: int
     pending_requests: list[AccountRequest]
+
+
+@dataclass(frozen=True)
+class MiddlewarePricedToken:
+    """A token a balance fuse will price via the IPOR PriceOracleMiddleware.
+
+    Derived from a granted substrate (e.g. the ``asset()`` of a granted Euler
+    vault). ``token`` is the lowercase address passed to ``getAssetPrice``;
+    ``via`` describes the derivation for health-check messages;
+    ``zero_balance_reverts`` is True when the fuse prices the token *before*
+    any balance check, so a missing feed reverts ``balanceOf()`` even with no
+    position.
+    """
+
+    token: str
+    via: str
+    zero_balance_reverts: bool
 
 
 @dataclass
@@ -105,6 +123,18 @@ class _VaultData:
     # vault's PriceOracleMiddleware. Missing keys mean the oracle has no source
     # configured for that token.
     token_prices_usd: dict[str, float] | None = None
+    # Lowercase addresses of tokens the PriceOracleMiddleware cannot price at
+    # all (no explicit feed source AND getAssetPrice reverts, so no registry
+    # fallback either — see _fetch_unpriceable_tokens). Used to flag
+    # unpriceable Morpho collateral and middleware-priced substrates (a
+    # totalAssets-DoS class). None means the check did not run.
+    unpriceable_tokens: frozenset[str] | None = None
+    # Tokens that balance fuses price via the IPOR PriceOracleMiddleware,
+    # derived from granted substrates and keyed by market_id. Joined with
+    # unpriceable_tokens to flag granted substrates whose priced token cannot
+    # be priced (balanceOf() reverts -> totalAssets DoS). See
+    # _fetch_middleware_priced_substrates.
+    middleware_priced_substrates: dict[int, list[MiddlewarePricedToken]] | None = None
     # MARKET_ID() reported by each registered action fuse. Keyed by checksummed
     # fuse address. Fuses that don't expose MARKET_ID() (or whose call reverts)
     # are absent from the dict — used to detect orphan markets (action fuses
@@ -125,6 +155,9 @@ def _safe_call(func: Callable[[], T]) -> T | None:
 
 
 _MARKET_ID_SELECTOR = function_signature_to_4byte_selector("MARKET_ID()")
+_ASSET_SELECTOR = function_signature_to_4byte_selector("asset()")
+_GET_SILOS_SELECTOR = function_signature_to_4byte_selector("getSilos()")
+_GET_PRICE_ORACLE_SELECTOR = function_signature_to_4byte_selector("getPriceOracle()")
 
 
 def _fetch_fuse_market_id(ctx: Web3Context, fuse_addr: ChecksumAddress) -> int | None:
@@ -374,6 +407,267 @@ def _fetch_breakdown_token_prices(
     return prices or None
 
 
+def _price_reverts_deterministically(
+    oracle: PriceOracleMiddleware, addr: ChecksumAddress
+) -> bool | None:
+    """Probe ``getAssetPrice``: True = deterministic revert (unpriceable),
+    False = priced fine, None = transient failure (unknown)."""
+    try:
+        oracle.get_asset_price(addr).call()
+        return False
+    except ContractLogicError:
+        return True
+    except (Web3RPCError, TimeExhausted):
+        return None
+
+
+def _fetch_unpriceable_tokens(
+    pool: ThreadPoolExecutor,
+    oracle: PriceOracleMiddleware,
+    addresses: set[ChecksumAddress],
+) -> frozenset[str] | None:
+    """Return the (lowercase) tokens the middleware cannot price at all.
+
+    Covers breakdown tokens (Morpho/Aave positions) plus substrate-derived
+    tokens from ``_fetch_middleware_priced_substrates``. A token is unpriceable
+    only when BOTH hold:
+
+    - ``getSourceOfAssetPrice`` returns the zero address (no explicit feed),
+      AND
+    - ``getAssetPrice`` reverts deterministically (``ContractLogicError``).
+
+    The second probe is required because on Ethereum mainnet the middleware
+    falls back to the Chainlink Feed Registry when no explicit source is set —
+    a zero source alone does not mean the token is unpriceable (e.g. USDC is
+    registry-priced on several mainnet vaults). Transient RPC failures at
+    either step leave the token out of the result (never a false alarm).
+    Returns ``None`` when there was nothing to check.
+    """
+    if not addresses:
+        return None
+    source_futs = {
+        addr: pool.submit(
+            _safe_call, lambda a=addr: oracle.get_source_of_asset_price(a).call()
+        )
+        for addr in addresses
+    }
+    zero_source = [
+        addr
+        for addr, fut in source_futs.items()
+        if (source := fut.result()) is not None and int(str(source), 16) == 0
+    ]
+    probe_futs = {
+        addr: pool.submit(_price_reverts_deterministically, oracle, addr)
+        for addr in zero_source
+    }
+    return frozenset(
+        addr.lower() for addr, fut in probe_futs.items() if fut.result() is True
+    )
+
+
+def _decode_address_call(raw: bytes | None) -> ChecksumAddress | None:
+    if not raw:
+        return None
+    try:
+        (addr,) = decode(["address"], raw)
+    except Exception:
+        return None
+    if int(addr, 16) == 0:
+        return None
+    return Web3.to_checksum_address(addr)
+
+
+def _fetch_erc4626_asset(ctx: Web3Context, vault_addr: str) -> ChecksumAddress | None:
+    """Read ``asset()`` of an ERC4626-style vault (Euler vault, Silo)."""
+    checksum = Web3.to_checksum_address(vault_addr)
+    return _decode_address_call(_safe_call(lambda: ctx.call(checksum, _ASSET_SELECTOR)))
+
+
+def _fetch_silo_assets(ctx: Web3Context, config_addr: str) -> list[tuple[str, str]]:
+    """Resolve a Silo Config substrate to its two silos' underlying assets.
+
+    Returns ``[(silo, asset), ...]`` — SiloV2BalanceFuse prices ``asset()`` of
+    both silos returned by ``ISiloConfig.getSilos()``.
+    """
+    checksum = Web3.to_checksum_address(config_addr)
+    raw = _safe_call(lambda: ctx.call(checksum, _GET_SILOS_SELECTOR))
+    if not raw:
+        return []
+    try:
+        silos = decode(["address", "address"], raw)
+    except Exception:
+        return []
+    pairs: list[tuple[str, str]] = []
+    for silo in silos:
+        if int(silo, 16) == 0:
+            continue
+        if asset := _fetch_erc4626_asset(ctx, silo):
+            pairs.append((Web3.to_checksum_address(silo), asset))
+    return pairs
+
+
+def _is_middleware_priced_aave_v3(ctx: Web3Context, fuse_addr: str) -> bool:
+    """Heuristic: is an Aave V3 balance fuse the middleware-priced variant?
+
+    The standard ``AaveV3BalanceFuse`` prices via Aave's own oracle, which it
+    must resolve through ``IPoolAddressesProvider.getPriceOracle()`` — that
+    selector appears as a PUSH4 in its deployed bytecode.
+    ``AaveV3WithPriceOracleMiddlewareBalanceFuse`` never calls it (it uses the
+    vault's PriceOracleMiddleware). Both variants expose identical public
+    getters, so bytecode is the only on-chain discriminator. A false negative
+    (selector bytes occurring by chance) only silences the health check.
+    """
+    code = _safe_call(
+        lambda: ctx.web3.eth.get_code(Web3.to_checksum_address(fuse_addr))
+    )
+    if not code:
+        return False
+    return _GET_PRICE_ORACLE_SELECTOR not in bytes(code)
+
+
+def _substrate_high_address(sub: bytes) -> str | None:
+    """Address packed in the high 20 bytes (Euler, Dolomite substrates)."""
+    hex_str = sub.hex()
+    if len(hex_str) != 64 or int(hex_str[0:40], 16) == 0:
+        return None
+    return f"0x{hex_str[0:40]}"
+
+
+def _substrate_low_address(sub: bytes) -> str | None:
+    """Address packed in the low 20 bytes (plain-address substrates)."""
+    hex_str = sub.hex()
+    if len(hex_str) != 64 or int(hex_str[24:], 16) == 0:
+        return None
+    return f"0x{hex_str[24:]}"
+
+
+def _fetch_middleware_priced_substrates(
+    ctx: Web3Context,
+    pool: ThreadPoolExecutor,
+    market_substrates: dict[int, list[bytes]],
+    balance_fuses: list,
+) -> dict[int, list[MiddlewarePricedToken]] | None:
+    """Derive, per market, the tokens its balance fuse prices via the IPOR
+    PriceOracleMiddleware.
+
+    Covered fuses (verified against ipor-fusion contracts @ origin/main):
+
+    - Euler V2 (11): prices ``ERC4626(eulerVault).asset()`` of every granted
+      substrate *before* checking the balance — reverts even at zero position.
+    - Silo V2 (35): prices ``ISilo(silo).asset()`` for both silos of every
+      granted Silo Config, also before the balance check.
+    - Aave V3 middleware variant (markets 1/20 when the balance fuse is
+      ``AaveV3WithPriceOracleMiddlewareBalanceFuse``): prices every granted
+      substrate asset unconditionally.
+    - Dolomite (47): prices the substrate asset only when the Dolomite Wei
+      balance is non-zero — but third-party deposits on the vault's behalf
+      can create one.
+    - Aave V4 (44): prices a spoke reserve's underlying only when it is a
+      granted Asset substrate with a non-zero position — permissionless
+      supply-on-behalf can create one. Skipped when no Spoke substrate is
+      granted (the fuse iterates spokes, so nothing is ever priced).
+    """
+    result: dict[int, list[MiddlewarePricedToken]] = {}
+    fuse_by_market = {bf.market_id: bf.fuse for bf in balance_fuses}
+
+    euler_futs: list[tuple[str, Future]] = []
+    silo_futs: list[Future] = []
+
+    for mid, subs in market_substrates.items():
+        tokens: list[MiddlewarePricedToken] = []
+
+        if mid == IporFusionMarkets.EULER_V2:
+            euler_futs.extend(
+                (vault, pool.submit(_fetch_erc4626_asset, ctx, vault))
+                for sub in subs
+                if (vault := _substrate_high_address(sub))
+            )
+        elif mid == IporFusionMarkets.SILO_V2:
+            silo_futs.extend(
+                pool.submit(_fetch_silo_assets, ctx, config)
+                for sub in subs
+                if (config := _substrate_low_address(sub))
+            )
+        elif mid == IporFusionMarkets.DOLOMITE:
+            tokens = _dolomite_priced_tokens(subs)
+        elif mid == IporFusionMarkets.AAVE_V4:
+            tokens = _aave_v4_priced_tokens(subs)
+        elif mid in AAVE_V3_MARKET_IDS:
+            tokens = _aave_v3_mw_priced_tokens(ctx, fuse_by_market.get(mid), subs)
+
+        if tokens:
+            result[mid] = tokens
+
+    euler_tokens = [
+        MiddlewarePricedToken(
+            token=asset.lower(),
+            via=f"underlying of granted Euler vault {vault}",
+            zero_balance_reverts=True,
+        )
+        for vault, fut in euler_futs
+        if (asset := fut.result()) is not None
+    ]
+    if euler_tokens:
+        result.setdefault(IporFusionMarkets.EULER_V2, []).extend(euler_tokens)
+
+    silo_tokens = [
+        MiddlewarePricedToken(
+            token=asset.lower(),
+            via=f"asset of granted Silo {silo}",
+            zero_balance_reverts=True,
+        )
+        for fut in silo_futs
+        for silo, asset in fut.result()
+    ]
+    if silo_tokens:
+        result.setdefault(IporFusionMarkets.SILO_V2, []).extend(silo_tokens)
+
+    return result or None
+
+
+def _dolomite_priced_tokens(subs: list[bytes]) -> list[MiddlewarePricedToken]:
+    return [
+        MiddlewarePricedToken(
+            token=asset.lower(),
+            via="granted Dolomite asset substrate",
+            zero_balance_reverts=False,
+        )
+        for sub in subs
+        if (asset := _substrate_high_address(sub))
+    ]
+
+
+def _aave_v4_priced_tokens(subs: list[bytes]) -> list[MiddlewarePricedToken]:
+    hexes = [s.hex() for s in subs if len(s.hex()) == 64]
+    if not any(int(h[0:2], 16) == 2 for h in hexes):  # no Spoke granted
+        return []
+    return [
+        MiddlewarePricedToken(
+            token=f"0x{h[24:]}".lower(),
+            via="granted Aave V4 Asset substrate",
+            zero_balance_reverts=False,
+        )
+        for h in hexes
+        if int(h[0:2], 16) == 1 and int(h[24:], 16) != 0
+    ]
+
+
+def _aave_v3_mw_priced_tokens(
+    ctx: Web3Context, fuse_addr: str | None, subs: list[bytes]
+) -> list[MiddlewarePricedToken]:
+    if not fuse_addr or not _is_middleware_priced_aave_v3(ctx, fuse_addr):
+        return []
+    return [
+        MiddlewarePricedToken(
+            token=asset.lower(),
+            via="granted substrate asset (middleware-priced Aave V3 balance fuse)",
+            zero_balance_reverts=True,
+        )
+        for sub in subs
+        if (asset := _substrate_low_address(sub))
+    ]
+
+
 def _fetch_vault_data(
     ctx: Web3Context,
     plasma_vault: PlasmaVault,
@@ -485,15 +779,26 @@ def _fetch_vault_data(
             aave_positions = _fetch_aave_positions(
                 ctx, pool, vault_addr, chain_id, market_substrates
             )
-            token_prices_usd = _fetch_breakdown_token_prices(
-                pool,
-                oracle,
-                _collect_breakdown_token_addresses(morpho_positions, aave_positions),
+            breakdown_addrs = _collect_breakdown_token_addresses(
+                morpho_positions, aave_positions
             )
+            token_prices_usd = _fetch_breakdown_token_prices(
+                pool, oracle, breakdown_addrs
+            )
+            middleware_priced = _fetch_middleware_priced_substrates(
+                ctx, pool, market_substrates, balance_fuses
+            )
+            source_addrs = set(breakdown_addrs)
+            for tokens in (middleware_priced or {}).values():
+                for mpt in tokens:
+                    source_addrs.add(Web3.to_checksum_address(mpt.token))
+            unpriceable_tokens = _fetch_unpriceable_tokens(pool, oracle, source_addrs)
         else:
             morpho_positions = None
             aave_positions = None
             token_prices_usd = None
+            unpriceable_tokens = None
+            middleware_priced = None
             market_substrates = {}
 
         return _VaultData(
@@ -523,6 +828,8 @@ def _fetch_vault_data(
             morpho_positions=morpho_positions,
             aave_positions=aave_positions,
             token_prices_usd=token_prices_usd,
+            unpriceable_tokens=unpriceable_tokens,
+            middleware_priced_substrates=middleware_priced,
             fuse_markets=fuse_markets or None,
             market_substrates=market_substrates or None,
         )

--- a/src/ipor_fusion/cli/vault_health.py
+++ b/src/ipor_fusion/cli/vault_health.py
@@ -503,6 +503,91 @@ def _compute_missing_erc20_dep_criticals(data: _VaultData) -> list[str]:
     ]
 
 
+def _compute_unpriceable_collateral_criticals(data: _VaultData) -> list[str]:
+    """Flag Morpho collateral tokens that have no price feed in the middleware.
+
+    ``MorphoBalanceFuse.balanceOf()`` iterates every whitelisted Morpho market
+    and prices the collateral leg whenever it is non-zero. Because Morpho's
+    ``supplyCollateral`` is permissionless in ``onBehalf``, anyone can push
+    collateral onto the vault's position in a whitelisted market; if that
+    market's collateral token has no feed, ``getAssetPrice`` reverts,
+    ``balanceOf`` reverts, and ``totalAssets`` (deposits/withdrawals/
+    reconciliation) is bricked.
+
+    The check keys off whitelisted substrates (via the per-market breakdown),
+    not current positions, so it catches the exposure *before* it is exploited.
+    ``unpriceable_tokens`` holds only tokens confirmed unpriceable (no explicit
+    feed AND ``getAssetPrice`` reverts — the mainnet middleware can fall back
+    to the Chainlink Feed Registry, so a missing source alone is not enough);
+    transient read failures never land in it, so no false alarms.
+    """
+    if not data.morpho_positions or not data.unpriceable_tokens:
+        return []
+    lines: list[str] = []
+    seen: set[str] = set()
+    for market_id, breakdowns in data.morpho_positions.items():
+        for pb in breakdowns:
+            key = pb.collateral_token.lower()
+            if key in seen or key not in data.unpriceable_tokens:
+                continue
+            seen.add(key)
+            lines.append(
+                f"CRITICAL — Morpho market {market_id}: collateral token "
+                f"{pb.collateral_token} cannot be priced by the "
+                f"PriceOracleMiddleware — anyone can supplyCollateral "
+                f"onBehalf of the vault to make MorphoBalanceFuse."
+                f"balanceOf() revert, bricking totalAssets "
+                f"(deposits/withdrawals/reconciliation)"
+            )
+    return lines
+
+
+def _compute_unpriceable_substrate_criticals(data: _VaultData) -> list[str]:
+    """Flag granted substrates whose middleware-priced token has no feed.
+
+    Several balance fuses price tokens derived from granted substrates via the
+    vault's PriceOracleMiddleware; ``getAssetPrice`` reverts when no feed is
+    configured, so ``balanceOf()`` reverts and ``totalAssets`` (deposits/
+    withdrawals/reconciliation) is bricked. Silo V2, Euler V2 and the
+    middleware-priced Aave V3 fuse price *before* any balance check, so a
+    granted feed-less substrate reverts at the next balance update of that
+    market even with a zero position. Dolomite and Aave V4 price only non-zero
+    balances — but those protocols accept third-party deposits on the vault's
+    behalf, so anyone can trigger the revert (same class as the Morpho
+    collateral check above).
+
+    Token derivation happens in ``_fetch_middleware_priced_substrates``;
+    ``unpriceable_tokens`` holds only tokens confirmed unpriceable (no
+    explicit feed AND ``getAssetPrice`` reverts — see
+    ``_fetch_unpriceable_tokens``), so registry-priced tokens and transient
+    read failures are never flagged.
+    """
+    if not data.middleware_priced_substrates or not data.unpriceable_tokens:
+        return []
+    lines: list[str] = []
+    seen: set[tuple[int, str]] = set()
+    for market_id, tokens in sorted(data.middleware_priced_substrates.items()):
+        for mpt in tokens:
+            key = (market_id, mpt.token)
+            if key in seen or mpt.token not in data.unpriceable_tokens:
+                continue
+            seen.add(key)
+            tail = (
+                "balanceOf() reverts even at zero balance, bricking "
+                "totalAssets at the next balance update of this market"
+                if mpt.zero_balance_reverts
+                else "any non-zero balance (third parties can deposit on the "
+                "vault's behalf) makes balanceOf() revert, bricking "
+                "totalAssets"
+            )
+            lines.append(
+                f"CRITICAL — market {_format_market_label(market_id)}: "
+                f"{mpt.via} — token {mpt.token} cannot be priced by the "
+                f"PriceOracleMiddleware — {tail}"
+            )
+    return lines
+
+
 def _compute_health_check(  # noqa: C901
     data: _VaultData,
     bf_totals: _BalanceFuseTotals,
@@ -517,6 +602,8 @@ def _compute_health_check(  # noqa: C901
 
     result.criticals.extend(_compute_orphan_fuse_criticals(data))
     result.criticals.extend(_compute_missing_erc20_dep_criticals(data))
+    result.criticals.extend(_compute_unpriceable_collateral_criticals(data))
+    result.criticals.extend(_compute_unpriceable_substrate_criticals(data))
 
     # Lending health warnings
     if data.lending_health and data.lending_health.has_lending_positions:

--- a/src/ipor_fusion/cli/vault_substrate.py
+++ b/src/ipor_fusion/cli/vault_substrate.py
@@ -139,7 +139,7 @@ _register_markets(
         35,
         37,
         40,
-        47,
+        46,  # Napier — plain Principal Token / input token addresses
         *range(100_001, 100_021),  # ERC4626_0001 .. ERC4626_0020
     ],
     _decode_plain_address,
@@ -202,8 +202,8 @@ _register_markets(
 )
 # Enso
 _register_markets([38], _decode_enso)
-# Dolomite
-_register_markets([46], _decode_dolomite)
+# Dolomite (renumbered 46 -> 47 upstream when Napier took 46)
+_register_markets([47], _decode_dolomite)
 # Euler V2 (eulerVault<<96 | isCollateral<<88 | canBorrow<<80 | subAccounts<<72)
 _register_markets([11], _decode_euler_v2)
 

--- a/src/ipor_fusion/market_ids.py
+++ b/src/ipor_fusion/market_ids.py
@@ -69,8 +69,11 @@ class IporFusionMarkets:
     AAVE_V4 = 44
     # substrate type: MidasSubstrateType
     MIDAS = 45
+    # substrate type: address (Napier V2 Principal Tokens / input tokens)
+    NAPIER = 46
     # substrate type: DolomiteSubstrate (asset, subAccountId, canBorrow)
-    DOLOMITE = 46
+    # (was 46 pre-release; renumbered to 47 when Napier took 46 upstream)
+    DOLOMITE = 47
     ERC4626_0001 = 100_001
     ERC4626_0002 = 100_002
     ERC4626_0003 = 100_003

--- a/tests/test_cli_health_unpriceable_collateral.py
+++ b/tests/test_cli_health_unpriceable_collateral.py
@@ -1,0 +1,82 @@
+"""Unit tests for the unpriceable-Morpho-collateral health critical.
+
+Exercises the pure helper ``_compute_unpriceable_collateral_criticals`` with
+duck-typed fixtures — it only reads ``data.morpho_positions`` (a dict of
+market_id -> breakdowns with a ``collateral_token``) and
+``data.unpriceable_tokens`` (lowercase addresses confirmed unpriceable by
+``_fetch_unpriceable_tokens``), so no chain access or full ``_VaultData``
+construction is needed.
+"""
+
+from types import SimpleNamespace
+
+from ipor_fusion.cli.vault_health import _compute_unpriceable_collateral_criticals
+
+_CB_BTC = "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+_WETH = "0x4200000000000000000000000000000000000006"
+
+
+def _breakdown(collateral_token: str) -> SimpleNamespace:
+    return SimpleNamespace(collateral_token=collateral_token)
+
+
+def _data(morpho_positions, unpriceable_tokens) -> SimpleNamespace:
+    return SimpleNamespace(
+        morpho_positions=morpho_positions,
+        unpriceable_tokens=unpriceable_tokens,
+    )
+
+
+def test_flags_unpriceable_collateral():
+    data = _data({14: [_breakdown(_CB_BTC)]}, frozenset({_CB_BTC.lower()}))
+    criticals = _compute_unpriceable_collateral_criticals(data)
+    assert len(criticals) == 1
+    assert _CB_BTC in criticals[0]
+    assert "supplyCollateral" in criticals[0]
+
+
+def test_no_flag_when_priceable():
+    # Priceable via explicit feed or the mainnet Chainlink registry fallback —
+    # either way the token is absent from unpriceable_tokens.
+    data = _data({14: [_breakdown(_WETH)]}, frozenset({_CB_BTC.lower()}))
+    assert _compute_unpriceable_collateral_criticals(data) == []
+
+
+def test_dedupes_same_collateral_across_markets():
+    data = _data(
+        {14: [_breakdown(_CB_BTC)], 15: [_breakdown(_CB_BTC)]},
+        frozenset({_CB_BTC.lower()}),
+    )
+    assert len(_compute_unpriceable_collateral_criticals(data)) == 1
+
+
+def test_mixed_flags_only_unpriceable():
+    data = _data(
+        {14: [_breakdown(_WETH), _breakdown(_CB_BTC)]},
+        frozenset({_CB_BTC.lower()}),
+    )
+    criticals = _compute_unpriceable_collateral_criticals(data)
+    assert len(criticals) == 1
+    assert _CB_BTC in criticals[0]
+    assert _WETH not in criticals[0]
+
+
+def test_empty_when_no_morpho_positions_or_unpriceable_set():
+    assert (
+        _compute_unpriceable_collateral_criticals(
+            _data(None, frozenset({_CB_BTC.lower()}))
+        )
+        == []
+    )
+    assert (
+        _compute_unpriceable_collateral_criticals(
+            _data({14: [_breakdown(_CB_BTC)]}, None)
+        )
+        == []
+    )
+    assert (
+        _compute_unpriceable_collateral_criticals(
+            _data({14: [_breakdown(_CB_BTC)]}, frozenset())
+        )
+        == []
+    )

--- a/tests/test_cli_health_unpriceable_substrate.py
+++ b/tests/test_cli_health_unpriceable_substrate.py
@@ -1,0 +1,141 @@
+"""Unit tests for the unpriceable middleware-priced-substrate health critical.
+
+Two layers are covered without chain access:
+
+- ``_compute_unpriceable_substrate_criticals`` (vault_health) with duck-typed
+  fixtures — it only reads ``data.middleware_priced_substrates`` (market_id ->
+  ``MiddlewarePricedToken``-shaped entries) and ``data.unpriceable_tokens``
+  (lowercase addresses confirmed unpriceable by ``_fetch_unpriceable_tokens``).
+- The pure (no-RPC) branches of ``_fetch_middleware_priced_substrates``
+  (vault_fetcher): Dolomite substrate decoding and the Aave V4 Asset/Spoke
+  gating. Euler/Silo/Aave-V3 branches need RPC and are not exercised here.
+"""
+
+from types import SimpleNamespace
+
+from ipor_fusion.cli.vault_fetcher import (
+    MiddlewarePricedToken,
+    _fetch_middleware_priced_substrates,
+)
+from ipor_fusion.cli.vault_health import _compute_unpriceable_substrate_criticals
+from ipor_fusion.market_ids import IporFusionMarkets
+
+_ASSET_A = "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
+_ASSET_B = "0x4200000000000000000000000000000000000006"
+
+
+def _mpt(token: str, zero_balance_reverts: bool = True) -> MiddlewarePricedToken:
+    return MiddlewarePricedToken(
+        token=token,
+        via="granted test substrate",
+        zero_balance_reverts=zero_balance_reverts,
+    )
+
+
+def _data(middleware_priced_substrates, unpriceable_tokens) -> SimpleNamespace:
+    return SimpleNamespace(
+        middleware_priced_substrates=middleware_priced_substrates,
+        unpriceable_tokens=unpriceable_tokens,
+    )
+
+
+class TestComputeUnpriceableSubstrateCriticals:
+    def test_flags_unpriceable_token(self):
+        data = _data({35: [_mpt(_ASSET_A)]}, frozenset({_ASSET_A}))
+        criticals = _compute_unpriceable_substrate_criticals(data)
+        assert len(criticals) == 1
+        assert _ASSET_A in criticals[0]
+        assert "even at zero balance" in criticals[0]
+
+    def test_conditional_fuse_gets_deposit_on_behalf_wording(self):
+        data = _data(
+            {47: [_mpt(_ASSET_A, zero_balance_reverts=False)]},
+            frozenset({_ASSET_A}),
+        )
+        criticals = _compute_unpriceable_substrate_criticals(data)
+        assert len(criticals) == 1
+        assert "deposit on the vault's behalf" in criticals[0]
+
+    def test_no_flag_when_priceable(self):
+        # Priceable via explicit feed or the mainnet Chainlink registry
+        # fallback — either way absent from unpriceable_tokens.
+        data = _data({35: [_mpt(_ASSET_B)]}, frozenset({_ASSET_A}))
+        assert _compute_unpriceable_substrate_criticals(data) == []
+
+    def test_dedupes_same_token_within_market(self):
+        data = _data({11: [_mpt(_ASSET_A), _mpt(_ASSET_A)]}, frozenset({_ASSET_A}))
+        assert len(_compute_unpriceable_substrate_criticals(data)) == 1
+
+    def test_same_token_in_two_markets_flagged_per_market(self):
+        data = _data(
+            {11: [_mpt(_ASSET_A)], 35: [_mpt(_ASSET_A)]}, frozenset({_ASSET_A})
+        )
+        assert len(_compute_unpriceable_substrate_criticals(data)) == 2
+
+    def test_empty_when_no_data(self):
+        assert (
+            _compute_unpriceable_substrate_criticals(_data(None, frozenset({_ASSET_A})))
+            == []
+        )
+        assert (
+            _compute_unpriceable_substrate_criticals(
+                _data({35: [_mpt(_ASSET_A)]}, None)
+            )
+            == []
+        )
+        assert (
+            _compute_unpriceable_substrate_criticals(
+                _data({35: [_mpt(_ASSET_A)]}, frozenset())
+            )
+            == []
+        )
+
+
+def _dolomite_substrate(asset_hex40: str) -> bytes:
+    # asset<<96 | subAccountId<<88 | canBorrow<<80
+    return bytes.fromhex(asset_hex40 + "00" + "01" + "00" * 10)
+
+
+def _aave_v4_substrate(flag: int, addr_hex40: str) -> bytes:
+    # type flag in the MSB byte, address in the low 20 bytes
+    return bytes.fromhex(f"{flag:02x}" + "00" * 11 + addr_hex40)
+
+
+class TestFetchMiddlewarePricedSubstrates:
+    def test_dolomite_substrate_asset_collected(self):
+        subs = {IporFusionMarkets.DOLOMITE: [_dolomite_substrate("ab" * 20)]}
+        result = _fetch_middleware_priced_substrates(None, None, subs, [])
+        assert result is not None
+        tokens = result[IporFusionMarkets.DOLOMITE]
+        assert tokens == [
+            MiddlewarePricedToken(
+                token="0x" + "ab" * 20,
+                via="granted Dolomite asset substrate",
+                zero_balance_reverts=False,
+            )
+        ]
+
+    def test_aave_v4_assets_collected_only_with_spoke(self):
+        asset = _aave_v4_substrate(1, "ab" * 20)
+        spoke = _aave_v4_substrate(2, "cd" * 20)
+        with_spoke = _fetch_middleware_priced_substrates(
+            None, None, {IporFusionMarkets.AAVE_V4: [asset, spoke]}, []
+        )
+        assert with_spoke is not None
+        assert [t.token for t in with_spoke[IporFusionMarkets.AAVE_V4]] == [
+            "0x" + "ab" * 20
+        ]
+        # Without a granted Spoke the fuse never iterates reserves -> nothing
+        # is ever priced -> no exposure to report.
+        without_spoke = _fetch_middleware_priced_substrates(
+            None, None, {IporFusionMarkets.AAVE_V4: [asset]}, []
+        )
+        assert without_spoke is None
+
+    def test_zero_address_substrates_skipped(self):
+        subs = {IporFusionMarkets.DOLOMITE: [_dolomite_substrate("00" * 20)]}
+        assert _fetch_middleware_priced_substrates(None, None, subs, []) is None
+
+    def test_unrelated_markets_ignored(self):
+        subs = {IporFusionMarkets.MORPHO: [bytes(32)]}
+        assert _fetch_middleware_priced_substrates(None, None, subs, []) is None

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -324,10 +324,18 @@ class TestFormatSubstratePerMarket:
     def test_dolomite(self):
         addr_hex = "ab" * 20
         raw = bytes.fromhex(addr_hex + "05" + "01" + "00" * 10)
-        info = _format_substrate(raw, market_id=46)
+        info = _format_substrate(raw, market_id=47)
         assert info.address == f"0x{addr_hex}"
         assert info.extra["sub_account_id"] == "5"
         assert info.extra["can_borrow"] == "True"
+
+    # Napier (plain zero-padded Principal Token address; took market id 46
+    # from Dolomite, which moved to 47)
+    def test_napier_plain_address(self):
+        addr_hex = "ab" * 20
+        raw = bytes.fromhex("00" * 12 + addr_hex)
+        info = _format_substrate(raw, market_id=46)
+        assert info.address == f"0x{addr_hex}"
 
     # Euler V2 (eulerVault<<96 | isCollateral<<88 | canBorrow<<80 | subAccounts<<72)
     def test_euler_v2_supply_only(self):


### PR DESCRIPTION
totalAssets when a priced token cannot be priced. Extend the health check beyond Morpho collateral to every fuse with this exposure, keyed off granted substrates so it fires before the vault bricks. Replace the zero-source test with a definitive probe: a token is flagged only when getSourceOfAssetPrice is zero AND getAssetPrice reverts deterministically. On mainnet the middleware falls back to the Chainlink Feed Registry when no explicit source is set, so a zero source alone is a false positive (e.g. USDC is registry-priced on several live vaults). This also fixes the same latent false positive in the Morpho collateral check, which had only been validated on Base (no registry there).

Also sync stale market ids with the contracts repo: Dolomite was renumbered 46 -> 47 when Napier took 46 (plain PT-address substrates).