### PR TITLE
Feat/vault role accounts

### DIFF
--- a/src/ipor_fusion/__init__.py
+++ b/src/ipor_fusion/__init__.py
@@ -6,6 +6,7 @@ from ipor_fusion.core.access import (
     RoleAccount,
     RoleStatus,
     resolve_access_manager,
+    role_account_sort_key,
 )
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.contract import Call
@@ -128,6 +129,7 @@ __all__ = [
     "RoleAccount",
     "RoleStatus",
     "resolve_access_manager",
+    "role_account_sort_key",
     "RewardsManager",
     "VestingData",
     "ERC20",

--- a/src/ipor_fusion/__init__.py
+++ b/src/ipor_fusion/__init__.py
@@ -1,7 +1,12 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from ipor_fusion.config.roles import Roles
-from ipor_fusion.core.access import AccessManager, RoleAccount, RoleStatus
+from ipor_fusion.core.access import (
+    AccessManager,
+    RoleAccount,
+    RoleStatus,
+    resolve_access_manager,
+)
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.contract import Call
 from ipor_fusion.core.erc20 import ERC20
@@ -20,7 +25,9 @@ from ipor_fusion.core.withdraw_manager import (
     WithdrawRequestInfo,
 )
 from ipor_fusion.errors import (
+    ContractNotFoundError,
     IporFusionError,
+    NotAPlasmaVaultError,
     TransactionError,
 )
 from ipor_fusion.fuses import (
@@ -120,6 +127,7 @@ __all__ = [
     "AccessManager",
     "RoleAccount",
     "RoleStatus",
+    "resolve_access_manager",
     "RewardsManager",
     "VestingData",
     "ERC20",
@@ -174,7 +182,9 @@ __all__ = [
     "euler_substrate",
     "Roles",
     "IporFusionMarkets",
+    "ContractNotFoundError",
     "IporFusionError",
+    "NotAPlasmaVaultError",
     "TransactionError",
     "Amount",
     "Shares",

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -46,6 +46,8 @@ from ipor_fusion.cli.vault_substrate import (
     _format_substrate,
     _market_name,
 )
+from ipor_fusion.config.roles import Roles
+from ipor_fusion.core.access import resolve_access_manager
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
 
@@ -336,6 +338,85 @@ def info(
     data = _fetch_vault_data(ctx, plasma_vault, block_number, chain_id=chain_id)
     _print_vault_info(
         ctx, plasma_vault, cfg, data, vault_address, chain_id, json_output
+    )
+
+
+@vault.command("role-accounts")
+@click.argument("vault_address", type=ADDRESS)
+@click.option(
+    "--role",
+    default="",
+    help="Filter to one role (case-insensitive, '_ROLE' suffix optional); "
+    f"omit to list all. Valid: {Roles.names_str()}.",
+)
+@click.option(
+    "--chain-id", type=CHAIN, default=None, help="Chain ID or name (e.g. 1, ethereum)."
+)
+@click.option(
+    "--block-number",
+    type=int,
+    default=None,
+    help="Block number (default: latest).",
+)
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output as JSON."
+)
+def role_accounts(
+    vault_address: str,
+    role: str,
+    chain_id: int | None,
+    block_number: int | None,
+    json_output: bool,
+) -> None:
+    """List confirmed role holders on the vault's AccessManager."""
+    cfg = load_config()
+    chain_id = _resolve_chain_id(cfg, vault_address, chain_id)
+    provider_url = _resolve_provider(cfg, chain_id)
+
+    ctx = Web3Context.from_url(provider_url)
+    if block_number is not None:
+        ctx.default_block = block_number
+
+    try:
+        role_id = None if not role.strip() else Roles.resolve(role)
+        manager = resolve_access_manager(ctx, vault_address)
+    except ValueError as exc:  # unknown role / no contract / not a vault
+        raise click.UsageError(str(exc)) from exc
+
+    accounts = (
+        manager.get_all_role_accounts()
+        if role_id is None
+        else manager.get_accounts_with_role(role_id)
+    )
+    accounts.sort(key=lambda ra: (ra.account.lower(), ra.role_id))
+
+    if json_output:
+        payload = {
+            "vault": Web3.to_checksum_address(vault_address),
+            "access_manager": manager.address,
+            "chain_id": chain_id,
+            "role_filter": Roles.get_name(role_id) if role_id is not None else None,
+            "accounts": [
+                {
+                    "account": ra.account,
+                    "role_id": ra.role_id,
+                    "role_name": ra.role_name,
+                    "is_member": ra.is_member,
+                    "execution_delay": ra.execution_delay,
+                }
+                for ra in accounts
+            ],
+        }
+        click.echo(json.dumps(payload, indent=2))
+        return
+
+    click.echo(f"Access Manager: {manager.address}")
+    _print_table(
+        ("Account", "Role", "Role ID", "Delay (s)"),
+        [
+            (ra.account, ra.role_name, str(ra.role_id), str(ra.execution_delay))
+            for ra in accounts
+        ],
     )
 
 

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -47,7 +47,7 @@ from ipor_fusion.cli.vault_substrate import (
     _market_name,
 )
 from ipor_fusion.config.roles import Roles
-from ipor_fusion.core.access import resolve_access_manager
+from ipor_fusion.core.access import AccessManager, resolve_access_manager
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
 
@@ -322,7 +322,11 @@ def info(
     block_number: int | None,
     json_output: bool,
 ) -> None:
-    """Display full on-chain vault state."""
+    """Display full on-chain vault state.
+
+    The comprehensive vault summary — includes all role accounts on the
+    vault's AccessManager.
+    """
     cfg = load_config()
     chain_id = _resolve_chain_id(cfg, vault_address, chain_id)
     provider_url = _resolve_provider(cfg, chain_id)
@@ -542,6 +546,49 @@ def _print_health_lines(market: Any, indent: str) -> None:
     click.secho(f"{indent}Status:        {status}", fg=color, bold=bold)
 
 
+def _fetch_role_accounts_json(
+    ctx: Web3Context, data: _VaultData
+) -> list[dict[str, Any]] | None:
+    """All confirmed role holders on the AccessManager, sorted; None when the
+    RoleGranted log scan fails (e.g. provider without broad eth_getLogs)."""
+    accounts = _safe_call(
+        lambda: AccessManager(ctx, data.access_manager).get_all_role_accounts()  # type: ignore[arg-type]
+    )
+    if accounts is None:
+        return None
+    accounts.sort(key=lambda ra: (ra.account.lower(), ra.role_id))
+    return [
+        {
+            "account": ra.account,
+            "role_id": ra.role_id,
+            "role_name": ra.role_name,
+            "is_member": ra.is_member,
+            "execution_delay": ra.execution_delay,
+        }
+        for ra in accounts
+    ]
+
+
+def _print_role_accounts(ctx: Web3Context, data: _VaultData) -> None:
+    click.echo("Role Accounts:")
+    if (role_accounts := _fetch_role_accounts_json(ctx, data)) is None:
+        click.echo("  (unavailable — provider could not serve the log scan)")
+    else:
+        _print_table(
+            ("Account", "Role", "Role ID", "Delay (s)"),
+            [
+                (
+                    entry["account"],
+                    entry["role_name"],
+                    str(entry["role_id"]),
+                    str(entry["execution_delay"]),
+                )
+                for entry in role_accounts
+            ],
+        )
+    click.echo()
+
+
 def _print_vault_info(
     ctx: Web3Context,
     plasma_vault: PlasmaVault,
@@ -649,6 +696,8 @@ def _print_vault_info(
             click.echo(f"  Last release:   {last_dt.strftime('%Y-%m-%dT%H:%M:%SZ')}")
         _print_pending_requests(data, plasma_vault)
     click.echo()
+
+    _print_role_accounts(ctx, data)
 
     _print_fuse_section(
         "Fuses",
@@ -1268,6 +1317,7 @@ def _build_json_output(  # noqa: C901, PLR0912, PLR0915
             "rewards": data.rewards_manager,
             "withdraw": data.withdraw_manager,
         },
+        "role_accounts": _fetch_role_accounts_json(ctx, data),
         "withdraw_manager_details": _build_withdraw_manager_json(data, plasma_vault),
         "fuses": fuses_json,
         "balance_fuses": balance_fuses_json,

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -49,7 +49,11 @@ from ipor_fusion.cli.vault_substrate import (
     _market_name,
 )
 from ipor_fusion.config.roles import Roles
-from ipor_fusion.core.access import AccessManager, resolve_access_manager
+from ipor_fusion.core.access import (
+    AccessManager,
+    resolve_access_manager,
+    role_account_sort_key,
+)
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
 from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
@@ -411,7 +415,7 @@ def role_accounts(
             f"RoleGranted log scan failed ({type(exc).__name__}: {exc}). "
             "The provider must serve broad eth_getLogs queries."
         ) from exc
-    accounts.sort(key=lambda ra: (ra.account.lower(), ra.role_id))
+    rows = [ra.to_dict() for ra in sorted(accounts, key=role_account_sort_key)]
 
     if json_output:
         payload = {
@@ -419,28 +423,13 @@ def role_accounts(
             "access_manager": manager.address,
             "chain_id": chain_id,
             "role_filter": Roles.get_name(role_id) if role_id is not None else None,
-            "accounts": [
-                {
-                    "account": ra.account,
-                    "role_id": ra.role_id,
-                    "role_name": ra.role_name,
-                    "is_member": ra.is_member,
-                    "execution_delay": ra.execution_delay,
-                }
-                for ra in accounts
-            ],
+            "accounts": rows,
         }
         click.echo(json.dumps(payload, indent=2))
         return
 
     click.echo(f"Access Manager: {manager.address}")
-    _print_table(
-        ("Account", "Role", "Role ID", "Delay (s)"),
-        [
-            (ra.account, ra.role_name, str(ra.role_id), str(ra.execution_delay))
-            for ra in accounts
-        ],
-    )
+    _print_role_accounts_table(rows)
 
 
 def _print_lending_health(  # noqa: C901
@@ -589,17 +578,22 @@ def _fetch_role_accounts_json(
         ).get_all_role_accounts()
     except _ROLE_SCAN_ERRORS:
         return None
-    accounts.sort(key=lambda ra: (ra.account.lower(), ra.role_id))
-    return [
-        {
-            "account": ra.account,
-            "role_id": ra.role_id,
-            "role_name": ra.role_name,
-            "is_member": ra.is_member,
-            "execution_delay": ra.execution_delay,
-        }
-        for ra in accounts
-    ]
+    return [ra.to_dict() for ra in sorted(accounts, key=role_account_sort_key)]
+
+
+def _print_role_accounts_table(role_accounts: list[dict[str, Any]]) -> None:
+    _print_table(
+        ("Account", "Role", "Role ID", "Delay (s)"),
+        [
+            (
+                entry["account"],
+                entry["role_name"],
+                str(entry["role_id"]),
+                str(entry["execution_delay"]),
+            )
+            for entry in role_accounts
+        ],
+    )
 
 
 def _print_role_accounts(role_accounts: list[dict[str, Any]] | None) -> None:
@@ -607,18 +601,7 @@ def _print_role_accounts(role_accounts: list[dict[str, Any]] | None) -> None:
     if role_accounts is None:
         click.echo("  (unavailable — provider could not serve the log scan)")
     else:
-        _print_table(
-            ("Account", "Role", "Role ID", "Delay (s)"),
-            [
-                (
-                    entry["account"],
-                    entry["role_name"],
-                    str(entry["role_id"]),
-                    str(entry["execution_delay"]),
-                )
-                for entry in role_accounts
-            ],
-        )
+        _print_role_accounts_table(role_accounts)
     click.echo()
 
 

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -187,6 +187,21 @@ def _resolve_provider(cfg: FusionConfig, chain_id: int) -> str:
     )
 
 
+def _build_ctx(
+    cfg: FusionConfig,
+    vault_address: str,
+    chain_id: int | None,
+    block_number: int | None,
+) -> tuple[int, Web3Context]:
+    """Shared command preamble: resolve chain + provider, build the context."""
+    chain_id = _resolve_chain_id(cfg, vault_address, chain_id)
+    provider_url = _resolve_provider(cfg, chain_id)
+    ctx = Web3Context.from_url(provider_url)
+    if block_number is not None:
+        ctx.default_block = block_number
+    return chain_id, ctx
+
+
 def _auto_save_vault(
     cfg: FusionConfig, vault_address: str, chain_id: int, plasma_vault: PlasmaVault
 ) -> None:
@@ -328,12 +343,7 @@ def info(
     vault's AccessManager.
     """
     cfg = load_config()
-    chain_id = _resolve_chain_id(cfg, vault_address, chain_id)
-    provider_url = _resolve_provider(cfg, chain_id)
-
-    ctx = Web3Context.from_url(provider_url)
-    if block_number is not None:
-        ctx.default_block = block_number
+    chain_id, ctx = _build_ctx(cfg, vault_address, chain_id, block_number)
     checksum_address = Web3.to_checksum_address(vault_address)
     plasma_vault = PlasmaVault(ctx, checksum_address)
 
@@ -374,12 +384,7 @@ def role_accounts(
 ) -> None:
     """List confirmed role holders on the vault's AccessManager."""
     cfg = load_config()
-    chain_id = _resolve_chain_id(cfg, vault_address, chain_id)
-    provider_url = _resolve_provider(cfg, chain_id)
-
-    ctx = Web3Context.from_url(provider_url)
-    if block_number is not None:
-        ctx.default_block = block_number
+    chain_id, ctx = _build_ctx(cfg, vault_address, chain_id, block_number)
 
     try:
         role_id = None if not role.strip() else Roles.resolve(role)

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -352,6 +352,15 @@ def info(
     cfg = load_config()
     chain_id, ctx = _build_ctx(cfg, vault_address, chain_id, block_number)
     checksum_address = Web3.to_checksum_address(vault_address)
+
+    # Cheap single-call probe: friendly errors for "nothing deployed here" and
+    # "not a Plasma Vault" (revert and empty-return flavors alike) before the
+    # expensive fetch — and before auto-save can store a non-vault.
+    try:
+        resolve_access_manager(ctx, vault_address)
+    except (ContractNotFoundError, NotAPlasmaVaultError) as exc:
+        raise click.UsageError(str(exc)) from exc
+
     plasma_vault = PlasmaVault(ctx, checksum_address)
 
     _auto_save_vault(cfg, vault_address, chain_id, plasma_vault)

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -602,9 +602,9 @@ def _fetch_role_accounts_json(
     ]
 
 
-def _print_role_accounts(ctx: Web3Context, data: _VaultData) -> None:
+def _print_role_accounts(role_accounts: list[dict[str, Any]] | None) -> None:
     click.echo("Role Accounts:")
-    if (role_accounts := _fetch_role_accounts_json(ctx, data)) is None:
+    if role_accounts is None:
         click.echo("  (unavailable — provider could not serve the log scan)")
     else:
         _print_table(
@@ -646,6 +646,12 @@ def _print_vault_info(
         )
         click.echo(json.dumps(result, indent=2))
         return
+
+    # Start the heavy RoleGranted scan now; joined when its section prints.
+    # shutdown(wait=False) only stops new submissions — the task completes.
+    role_pool = ThreadPoolExecutor(max_workers=1)
+    role_accounts_fut = role_pool.submit(_fetch_role_accounts_json, ctx, data)
+    role_pool.shutdown(wait=False)
 
     total_assets_usd = _format_usd(
         data.total_assets, data.asset_decimals, data.asset_price_usd
@@ -730,7 +736,7 @@ def _print_vault_info(
         _print_pending_requests(data, plasma_vault)
     click.echo()
 
-    _print_role_accounts(ctx, data)
+    _print_role_accounts(role_accounts_fut.result())
 
     _print_fuse_section(
         "Fuses",
@@ -1014,6 +1020,9 @@ def _build_json_output(  # noqa: C901, PLR0912, PLR0915
 
     # Resolve fuse contract names in parallel
     with ThreadPoolExecutor() as pool:
+        # The heavy RoleGranted scan overlaps the fetches below; the with-block
+        # exit waits for it, so .result() in the return dict never blocks.
+        role_accounts_fut = pool.submit(_fetch_role_accounts_json, ctx, data)
         fuse_name_futs = {
             addr: pool.submit(get_contract_name, chain_id, addr, api_key)
             for addr in data.fuses
@@ -1350,7 +1359,7 @@ def _build_json_output(  # noqa: C901, PLR0912, PLR0915
             "rewards": data.rewards_manager,
             "withdraw": data.withdraw_manager,
         },
-        "role_accounts": _fetch_role_accounts_json(ctx, data),
+        "role_accounts": role_accounts_fut.result(),
         "withdraw_manager_details": _build_withdraw_manager_json(data, plasma_vault),
         "fuses": fuses_json,
         "balance_fuses": balance_fuses_json,

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -7,7 +7,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 import click
+import requests
 from web3 import Web3
+from web3.exceptions import ContractLogicError, TimeExhausted, Web3RPCError
 
 from ipor_fusion.cli.config_store import (
     FusionConfig,
@@ -50,6 +52,7 @@ from ipor_fusion.config.roles import Roles
 from ipor_fusion.core.access import AccessManager, resolve_access_manager
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
+from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
 
 
 class AddressType(click.ParamType):
@@ -383,20 +386,31 @@ def role_accounts(
     json_output: bool,
 ) -> None:
     """List confirmed role holders on the vault's AccessManager."""
+    # Pure input validation first — no RPC needed to reject a bad --role.
+    try:
+        role_id = None if not role.strip() else Roles.resolve(role)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
     cfg = load_config()
     chain_id, ctx = _build_ctx(cfg, vault_address, chain_id, block_number)
 
     try:
-        role_id = None if not role.strip() else Roles.resolve(role)
         manager = resolve_access_manager(ctx, vault_address)
-    except ValueError as exc:  # unknown role / no contract / not a vault
+    except (ContractNotFoundError, NotAPlasmaVaultError) as exc:
         raise click.UsageError(str(exc)) from exc
 
-    accounts = (
-        manager.get_all_role_accounts()
-        if role_id is None
-        else manager.get_accounts_with_role(role_id)
-    )
+    try:
+        accounts = (
+            manager.get_all_role_accounts()
+            if role_id is None
+            else manager.get_accounts_with_role(role_id)
+        )
+    except _ROLE_SCAN_ERRORS as exc:
+        raise click.ClickException(
+            f"RoleGranted log scan failed ({type(exc).__name__}: {exc}). "
+            "The provider must serve broad eth_getLogs queries."
+        ) from exc
     accounts.sort(key=lambda ra: (ra.account.lower(), ra.role_id))
 
     if json_output:
@@ -551,15 +565,29 @@ def _print_health_lines(market: Any, indent: str) -> None:
     click.secho(f"{indent}Status:        {status}", fg=color, bold=bold)
 
 
+# Failure modes of the heavy RoleGranted scan: JSON-RPC rejections/limits plus
+# transport-level errors — web3's HTTPProvider re-raises raw requests
+# exceptions (read timeouts, 429/5xx via raise_for_status).
+_ROLE_SCAN_ERRORS = (
+    ContractLogicError,
+    Web3RPCError,
+    TimeExhausted,
+    requests.RequestException,
+)
+
+
 def _fetch_role_accounts_json(
     ctx: Web3Context, data: _VaultData
 ) -> list[dict[str, Any]] | None:
     """All confirmed role holders on the AccessManager, sorted; None when the
-    RoleGranted log scan fails (e.g. provider without broad eth_getLogs)."""
-    accounts = _safe_call(
-        lambda: AccessManager(ctx, data.access_manager).get_all_role_accounts()  # type: ignore[arg-type]
-    )
-    if accounts is None:
+    RoleGranted log scan fails (provider without broad eth_getLogs support,
+    or a transport-level failure on the heavy query)."""
+    try:
+        accounts = AccessManager(
+            ctx,
+            data.access_manager,  # type: ignore[arg-type]
+        ).get_all_role_accounts()
+    except _ROLE_SCAN_ERRORS:
         return None
     accounts.sort(key=lambda ra: (ra.account.lower(), ra.role_id))
     return [

--- a/src/ipor_fusion/config/roles.py
+++ b/src/ipor_fusion/config/roles.py
@@ -1,3 +1,5 @@
+import difflib
+import re
 from enum import IntEnum
 
 
@@ -40,3 +42,29 @@ class Roles(IntEnum):
             return cls(value).name
         except ValueError:
             return f"UNKNOWN_ROLE_{value}"
+
+    @classmethod
+    def resolve(cls, name: str) -> int:
+        """Resolve a human-entered role name to its id (fail-closed).
+
+        Case-insensitive; spaces/hyphens map to underscores and the `_ROLE`
+        suffix is optional. Unknown (or blank) names raise `ValueError` listing
+        the valid names, with a "did you mean" hint on a near miss.
+        """
+        key = re.sub(r"[\s\-]+", "_", name.strip()).upper()
+        if not key.endswith("_ROLE"):
+            key += "_ROLE"
+        try:
+            return cls[key].value
+        except KeyError:
+            names = [role.name for role in cls]
+            near = difflib.get_close_matches(key, names, n=1)
+            hint = f" Did you mean {near[0]}?" if near else ""
+            raise ValueError(
+                f"Unknown role {name!r}.{hint} Valid: {cls.names_str()}"
+            ) from None
+
+    @classmethod
+    def names_str(cls) -> str:
+        """Canonical role names, comma-separated — for help texts and errors."""
+        return ", ".join(role.name for role in cls)

--- a/src/ipor_fusion/core/access.py
+++ b/src/ipor_fusion/core/access.py
@@ -29,6 +29,10 @@ class RoleAccount:
     is_member: bool
     execution_delay: Period
 
+    @property
+    def role_name(self) -> str:
+        return Roles.get_name(self.role_id)
+
 
 def _role_status_decoder(values: tuple) -> RoleStatus:
     is_member, execution_delay = values

--- a/src/ipor_fusion/core/access.py
+++ b/src/ipor_fusion/core/access.py
@@ -93,11 +93,16 @@ class AccessManager(ContractWrapper):
         # N+1 RPC: each candidate requires a has_role() call; multicall would fix
         # this but is out of scope.
         role_accounts: list[RoleAccount] = []
+        seen: set[tuple[int, str]] = set()
         for event in events:
             (role_id,) = decode(["uint64"], event["topics"][1])
             (account,) = decode(["address"], event["topics"][2])
             if not predicate(role_id, account):
                 continue
+            # A re-granted (role, account) emits multiple RoleGranted events.
+            if (role_id, account) in seen:
+                continue
+            seen.add((role_id, account))
             role_status = self.has_role(role_id, account).call()
             if role_status.is_member:
                 role_accounts.append(

--- a/src/ipor_fusion/core/access.py
+++ b/src/ipor_fusion/core/access.py
@@ -2,9 +2,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from eth_abi import decode
+from eth_abi.exceptions import InsufficientDataBytes
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from web3 import Web3
+from web3.exceptions import ContractLogicError
 from web3.types import LogReceipt
 
 from ipor_fusion.config.roles import Roles
@@ -138,24 +140,28 @@ def resolve_access_manager(
 ) -> AccessManager:
     """Resolve a vault address to its AccessManager, with typed guards.
 
-    Raises ContractNotFoundError when nothing is deployed at the address, and
-    NotAPlasmaVaultError when the contract does not expose
-    getAccessManagerAddress() (detected via the ABI decode failure on the
-    empty eth_call result).
+    Raises ContractNotFoundError when no code is deployed at the address (as
+    of ctx.default_block), and NotAPlasmaVaultError when the contract does not
+    expose getAccessManagerAddress() — either an empty eth_call return
+    (InsufficientDataBytes on decode) or a revert (ContractLogicError).
+    Provider/transport errors propagate unchanged.
     """
     checksum = Web3.to_checksum_address(vault_address)
-    code = ctx.web3.eth.get_code(checksum)
+    # Same block as the eth_call below, or a pre-deployment pin would pass
+    # this guard and get misdiagnosed as "not a vault".
+    code = ctx.web3.eth.get_code(checksum, block_identifier=ctx.default_block)
     if code in {b"", b"\x00"}:
+        block_note = (
+            f" at block {ctx.default_block}" if ctx.default_block != "latest" else ""
+        )
         raise ContractNotFoundError(
-            f"No contract found at {checksum} on chain {ctx.chain_id}."
+            f"No contract found at {checksum} on chain {ctx.chain_id}{block_note}."
         )
     try:
         manager_address = PlasmaVault(ctx, checksum).get_access_manager_address().call()
-    except Exception as exc:
-        if "Tried to read" in str(exc) and "only got 0 bytes" in str(exc):
-            raise NotAPlasmaVaultError(
-                f"Address {checksum} on chain {ctx.chain_id} does not appear "
-                f"to be a Plasma Vault."
-            ) from exc
-        raise
+    except (InsufficientDataBytes, ContractLogicError) as exc:
+        raise NotAPlasmaVaultError(
+            f"Address {checksum} on chain {ctx.chain_id} does not appear "
+            f"to be a Plasma Vault."
+        ) from exc
     return AccessManager(ctx, manager_address)

--- a/src/ipor_fusion/core/access.py
+++ b/src/ipor_fusion/core/access.py
@@ -8,7 +8,10 @@ from web3 import Web3
 from web3.types import LogReceipt
 
 from ipor_fusion.config.roles import Roles
+from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.contract import Call, ContractWrapper
+from ipor_fusion.core.plasma_vault import PlasmaVault
+from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
 from ipor_fusion.types import Period, RoleId
 
 
@@ -128,3 +131,31 @@ class AccessManager(ContractWrapper):
                 contract_address=self._address, topics=[event_signature_hash]
             )
         )
+
+
+def resolve_access_manager(
+    ctx: Web3Context, vault_address: ChecksumAddress
+) -> AccessManager:
+    """Resolve a vault address to its AccessManager, with typed guards.
+
+    Raises ContractNotFoundError when nothing is deployed at the address, and
+    NotAPlasmaVaultError when the contract does not expose
+    getAccessManagerAddress() (detected via the ABI decode failure on the
+    empty eth_call result).
+    """
+    checksum = Web3.to_checksum_address(vault_address)
+    code = ctx.web3.eth.get_code(checksum)
+    if code in {b"", b"\x00"}:
+        raise ContractNotFoundError(
+            f"No contract found at {checksum} on chain {ctx.chain_id}."
+        )
+    try:
+        manager_address = PlasmaVault(ctx, checksum).get_access_manager_address().call()
+    except Exception as exc:
+        if "Tried to read" in str(exc) and "only got 0 bytes" in str(exc):
+            raise NotAPlasmaVaultError(
+                f"Address {checksum} on chain {ctx.chain_id} does not appear "
+                f"to be a Plasma Vault."
+            ) from exc
+        raise
+    return AccessManager(ctx, manager_address)

--- a/src/ipor_fusion/core/access.py
+++ b/src/ipor_fusion/core/access.py
@@ -38,6 +38,21 @@ class RoleAccount:
     def role_name(self) -> str:
         return Roles.get_name(self.role_id)
 
+    def to_dict(self) -> dict[str, str | int | bool]:
+        """Canonical JSON-ready row shape, shared by the CLI surfaces."""
+        return {
+            "account": self.account,
+            "role_id": self.role_id,
+            "role_name": self.role_name,
+            "is_member": self.is_member,
+            "execution_delay": self.execution_delay,
+        }
+
+
+def role_account_sort_key(role_account: RoleAccount) -> tuple[str, int]:
+    """Canonical presentation order: account (case-insensitive), then role id."""
+    return (role_account.account.lower(), role_account.role_id)
+
 
 def _role_status_decoder(values: tuple) -> RoleStatus:
     is_member, execution_delay = values

--- a/src/ipor_fusion/errors.py
+++ b/src/ipor_fusion/errors.py
@@ -92,6 +92,20 @@ class IporFusionError(Exception):
     """Base exception for all IPOR Fusion SDK errors."""
 
 
+class ContractNotFoundError(IporFusionError, ValueError):
+    """No contract deployed at the given address.
+
+    Also a ValueError so MCP adapters can let it propagate unmapped.
+    """
+
+
+class NotAPlasmaVaultError(IporFusionError, ValueError):
+    """Contract exists but does not implement the Plasma Vault interface.
+
+    Also a ValueError so MCP adapters can let it propagate unmapped.
+    """
+
+
 class TransactionError(IporFusionError):
     def __init__(
         self,

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -211,19 +211,19 @@ class RoleAccountsResponse(_Base):
         role_filter: str | None,
     ) -> RoleAccountsResponse:
         """Build the response from SDK dataclasses (sorted for stable output)."""
-        entries = sorted(
-            (
-                RoleAccountEntry(
-                    account=ra.account,
-                    role_id=ra.role_id,
-                    role_name=ra.role_name,
-                    is_member=ra.is_member,
-                    execution_delay=ra.execution_delay,
-                )
-                for ra in accounts
-            ),
-            key=lambda e: (e.account.lower(), e.role_id),
-        )
+        # Deferred import keeps this module's import graph pydantic-only.
+        from ipor_fusion.core.access import role_account_sort_key
+
+        entries = [
+            RoleAccountEntry(
+                account=ra.account,
+                role_id=ra.role_id,
+                role_name=ra.role_name,
+                is_member=ra.is_member,
+                execution_delay=ra.execution_delay,
+            )
+            for ra in sorted(accounts, key=role_account_sort_key)
+        ]
         return cls(
             vault=vault,
             access_manager=access_manager,

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -372,6 +372,12 @@ class VaultInfoResponse(_Base):
     share_price: dict[str, Any] | None = None
     supply_cap: Amount
     managers: Managers
+    role_accounts: list[RoleAccountEntry] | None = Field(
+        default=None,
+        description="All confirmed role holders on the AccessManager; "
+        "null when the RoleGranted log scan failed (provider without "
+        "broad eth_getLogs support).",
+    )
     withdraw_manager_details: dict[str, Any] | None = None
     fuses: list[FuseEntry]
     balance_fuses: list[BalanceFuseEntry]

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -17,9 +17,12 @@ Design notes:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from ipor_fusion.core.access import RoleAccount
 
 
 class _Base(BaseModel):
@@ -164,6 +167,70 @@ class ConfigShowResponse(_Base):
         default=None,
         description="Masked ('***') when set, null when unset.",
     )
+
+
+# ---------------------------------------------------------------------------
+# Role-account models
+# ---------------------------------------------------------------------------
+
+
+class RoleAccountEntry(_Base):
+    """One confirmed role membership on a vault's AccessManager."""
+
+    account: str
+    role_id: int
+    role_name: str = Field(
+        description="Canonical enum name; UNKNOWN_ROLE_<id> when unmapped."
+    )
+    is_member: bool
+    execution_delay: int = Field(
+        description="Execution timelock in seconds (0 = immediate)."
+    )
+
+
+class RoleAccountsResponse(_Base):
+    """Role holders on a Plasma Vault's AccessManager."""
+
+    vault: str
+    access_manager: str
+    chain_id: int
+    role_filter: str | None = Field(
+        default=None,
+        description="Canonical role name when filtered; null = all roles.",
+    )
+    accounts: list[RoleAccountEntry]
+
+    @classmethod
+    def from_role_accounts(
+        cls,
+        accounts: list[RoleAccount],
+        *,
+        vault: str,
+        access_manager: str,
+        chain_id: int,
+        role_filter: str | None,
+    ) -> RoleAccountsResponse:
+        """Build the response from SDK dataclasses (sorted for stable output)."""
+        entries = sorted(
+            (
+                RoleAccountEntry(
+                    account=ra.account,
+                    role_id=ra.role_id,
+                    role_name=ra.role_name,
+                    is_member=ra.is_member,
+                    execution_delay=ra.execution_delay,
+                )
+                for ra in accounts
+            ),
+            key=lambda e: (e.account.lower(), e.role_id),
+        )
+        return cls(
+            vault=vault,
+            access_manager=access_manager,
+            chain_id=chain_id,
+            role_filter=role_filter,
+            accounts=entries,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -134,6 +134,7 @@ class LendingHealth(_Base):
 class HealthCheck(_Base):
     ok: bool
     warnings: list[str]
+    criticals: list[str]
 
 
 # ---------------------------------------------------------------------------

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -9,10 +9,12 @@ Design notes:
   position breakdowns) use dict[str, Any] / list[dict[str, Any]] — modelling
   every variant would be brittle without meaningful LLM-side benefit.
 - Models use extra="forbid": any new field added to _build_json_output that
-  is not declared here will fail VaultInfoResponse.model_validate(). This is
-  intentional — it forces CLI dict-builder and MCP model to stay in sync,
-  catching silent drift and typos at test time. See test_mcp_models.py for
-  the contract test that exercises every top-level field.
+  is not declared here will fail VaultInfoResponse.model_validate(). Drift
+  is caught at test time by the producer contract check in
+  test_cli_commands.py::TestVaultInfoJson::test_json_output, which validates
+  the real _build_json_output dict against this model. The samples in
+  test_mcp_models.py document the expected shape but are hand-maintained —
+  on their own they cannot detect producer drift.
 """
 
 from __future__ import annotations
@@ -70,6 +72,14 @@ class FuseEntry(_Base):
     address: str
     contract: str = Field(
         description="Contract name resolved via Etherscan; '?' if unknown."
+    )
+    market_id: int | None = Field(
+        default=None,
+        description="Market this fuse serves; absent when the fuse exposes none.",
+    )
+    market: str | None = Field(
+        default=None,
+        description="Human-readable market name (falls back to the id as string).",
     )
 
 
@@ -135,7 +145,9 @@ class LendingHealth(_Base):
 
 
 class HealthCheck(_Base):
-    ok: bool
+    ok: list[str] = Field(
+        description="Passing-check lines (one per healthy check), not a boolean."
+    )
     warnings: list[str]
     criticals: list[str]
 

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -4,6 +4,7 @@ Calls the ipor_fusion SDK directly — no CLI subprocess.
 Configuration is loaded from the shared CLI config (~/.config/ipor-fusion/).
 """
 
+from eth_abi.exceptions import InsufficientDataBytes
 from mcp.server.fastmcp import FastMCP
 from web3 import Web3
 
@@ -33,6 +34,7 @@ from ipor_fusion.config.roles import Roles
 from ipor_fusion.core.access import resolve_access_manager
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
+from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
 from ipor_fusion.mcp.models import (
     ActionResult,
     ConfigShowResponse,
@@ -116,21 +118,24 @@ def vault_info(
     ctx, effective_block = _build_ctx(cfg, chain_id, block_number)
     checksum = Web3.to_checksum_address(vault_address)
 
-    code = ctx.web3.eth.get_code(checksum)
+    code = ctx.web3.eth.get_code(checksum, block_identifier=ctx.default_block)
     if code in {b"", b"\x00"}:
-        raise ValueError(f"No contract found at {checksum} on chain {chain_id}.")
+        raise ContractNotFoundError(
+            f"No contract found at {checksum} on chain {chain_id}."
+        )
 
     plasma_vault = PlasmaVault(ctx, checksum)
 
     try:
         data = _fetch_vault_data(ctx, plasma_vault, effective_block, chain_id=chain_id)
-    except Exception as exc:
-        if "Tried to read" in str(exc) and "only got 0 bytes" in str(exc):
-            raise ValueError(
-                f"Address {checksum} on chain {chain_id} does not appear to be "
-                f"a Plasma Vault."
-            ) from exc
-        raise
+    except InsufficientDataBytes as exc:
+        # Unlike resolve_access_manager, no ContractLogicError catch here:
+        # _fetch_vault_data spans many calls, and a revert in one of them on a
+        # real vault must not be misdiagnosed as "not a vault".
+        raise NotAPlasmaVaultError(
+            f"Address {checksum} on chain {chain_id} does not appear to be "
+            f"a Plasma Vault."
+        ) from exc
 
     api_key = cfg.etherscan_api_key
     chain_label = CHAIN_NAMES.get(chain_id, str(chain_id))

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -29,6 +29,8 @@ from ipor_fusion.cli.vault_fetcher import (
     _fetch_deployment_info,
     _fetch_vault_data,
 )
+from ipor_fusion.config.roles import Roles
+from ipor_fusion.core.access import resolve_access_manager
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
 from ipor_fusion.mcp.models import (
@@ -36,6 +38,7 @@ from ipor_fusion.mcp.models import (
     ConfigShowResponse,
     MetaMorphoVaultResponse,
     MorphoBlueMarketResponse,
+    RoleAccountsResponse,
     VaultInfoResponse,
     VaultListEntry,
 )
@@ -141,6 +144,53 @@ def vault_info(
         ctx, plasma_vault, data, vault_address, chain_id, chain_label, api_key
     )
     return VaultInfoResponse.model_validate(result)
+
+
+def _role_accounts_description() -> str:
+    # Generated (not a docstring) so the role list always matches the enum.
+    return (
+        "List confirmed role holders on a Plasma Vault's AccessManager.\n"
+        "Pass `role` to filter to one role — matching is case-insensitive and "
+        "the `_ROLE` suffix is optional; omit it (empty string) to list all "
+        "roles.\n"
+        f"Valid roles: {Roles.names_str()}.\n"
+        "TECH_* roles are held by protocol contracts, not EOAs — expect "
+        "contract addresses for those.\n"
+        "Cost: scans RoleGranted logs + one hasRole read per unique "
+        "(role, account) pair; can be slow on vaults with many grants and "
+        "needs a provider that serves broad eth_getLogs queries.\n"
+        "Returns: vault, access_manager, chain_id, role_filter (canonical "
+        "name or null), and accounts[] of {account, role_id, role_name, "
+        "is_member, execution_delay}."
+    )
+
+
+@mcp.tool(description=_role_accounts_description())
+def vault_role_accounts(
+    vault_address: str,
+    role: str = "",
+    chain_id: int = 0,
+    block_number: int = 0,
+) -> RoleAccountsResponse:
+    cfg = load_config()
+    role_id = None if not role.strip() else Roles.resolve(role)
+    chain_id = _resolve_chain_id(cfg, vault_address, chain_id)
+    ctx, _ = _build_ctx(cfg, chain_id, block_number)
+    checksum = Web3.to_checksum_address(vault_address)
+
+    access_manager = resolve_access_manager(ctx, checksum)
+    accounts = (
+        access_manager.get_all_role_accounts()
+        if role_id is None
+        else access_manager.get_accounts_with_role(role_id)
+    )
+    return RoleAccountsResponse.from_role_accounts(
+        accounts,
+        vault=checksum,
+        access_manager=access_manager.address,
+        chain_id=chain_id,
+        role_filter=Roles.get_name(role_id) if role_id is not None else None,
+    )
 
 
 @mcp.tool()

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -4,7 +4,6 @@ Calls the ipor_fusion SDK directly — no CLI subprocess.
 Configuration is loaded from the shared CLI config (~/.config/ipor-fusion/).
 """
 
-from eth_abi.exceptions import InsufficientDataBytes
 from mcp.server.fastmcp import FastMCP
 from web3 import Web3
 
@@ -34,7 +33,6 @@ from ipor_fusion.config.roles import Roles
 from ipor_fusion.core.access import resolve_access_manager
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
-from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
 from ipor_fusion.mcp.models import (
     ActionResult,
     ConfigShowResponse,
@@ -118,24 +116,15 @@ def vault_info(
     ctx, effective_block = _build_ctx(cfg, chain_id, block_number)
     checksum = Web3.to_checksum_address(vault_address)
 
-    code = ctx.web3.eth.get_code(checksum, block_identifier=ctx.default_block)
-    if code in {b"", b"\x00"}:
-        raise ContractNotFoundError(
-            f"No contract found at {checksum} on chain {chain_id}."
-        )
+    # Cheap single-call probe: raises the typed ContractNotFoundError /
+    # NotAPlasmaVaultError ("not a vault" in both revert and empty-return
+    # flavors) before the expensive fetch. The fetch itself stays catch-free:
+    # once the probe passes, any later failure is a real error on a real
+    # vault and must stay loud.
+    resolve_access_manager(ctx, checksum)
 
     plasma_vault = PlasmaVault(ctx, checksum)
-
-    try:
-        data = _fetch_vault_data(ctx, plasma_vault, effective_block, chain_id=chain_id)
-    except InsufficientDataBytes as exc:
-        # Unlike resolve_access_manager, no ContractLogicError catch here:
-        # _fetch_vault_data spans many calls, and a revert in one of them on a
-        # real vault must not be misdiagnosed as "not a vault".
-        raise NotAPlasmaVaultError(
-            f"Address {checksum} on chain {chain_id} does not appear to be "
-            f"a Plasma Vault."
-        ) from exc
+    data = _fetch_vault_data(ctx, plasma_vault, effective_block, chain_id=chain_id)
 
     api_key = cfg.etherscan_api_key
     chain_label = CHAIN_NAMES.get(chain_id, str(chain_id))

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -100,11 +100,11 @@ def vault_info(
     chain_id: int = 0,
     block_number: int = 0,
 ) -> VaultInfoResponse:
-    """Get full on-chain state of a Plasma Vault.
+    """Get full on-chain state of a Plasma Vault — the comprehensive summary.
 
     Returns a structured VaultInfoResponse — see model field descriptions
     for the complete output schema (assets, balance fuses, reconciliation,
-    lending health, substrates, etc.).
+    lending health, substrates, role accounts, etc.).
 
     Args:
         vault_address: Vault address (required).

--- a/tests/test_access_manager.py
+++ b/tests/test_access_manager.py
@@ -1,0 +1,78 @@
+"""Unit tests for AccessManager role-account queries — mock Web3Context."""
+
+from unittest.mock import MagicMock
+
+from eth_abi import encode
+from web3 import Web3
+
+from ipor_fusion.core.access import AccessManager
+
+MANAGER_ADDR = Web3.to_checksum_address("0x1111111111111111111111111111111111111111")
+ALICE = Web3.to_checksum_address("0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa")
+BOB = Web3.to_checksum_address("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB")
+
+
+def _grant_event(role_id: int, account: str) -> dict:
+    return {
+        "topics": [
+            b"\x00" * 32,  # event signature hash — not read by the decoder
+            encode(["uint64"], [role_id]),
+            encode(["address"], [account]),
+        ]
+    }
+
+
+def _manager_with(
+    events: list[dict], is_member: bool = True, execution_delay: int = 0
+) -> AccessManager:
+    ctx = MagicMock()
+    ctx.get_logs.return_value = events
+    ctx.call.return_value = encode(["bool", "uint32"], [is_member, execution_delay])
+    return AccessManager(ctx, MANAGER_ADDR)
+
+
+class TestGetAllRoleAccounts:
+    def test_returns_confirmed_members(self):
+        manager = _manager_with([_grant_event(1, ALICE), _grant_event(100, BOB)])
+
+        accounts = manager.get_all_role_accounts()
+
+        assert [(ra.role_id, ra.account) for ra in accounts] == [
+            (1, ALICE),
+            (100, BOB),
+        ]
+
+    def test_skips_revoked_members(self):
+        manager = _manager_with([_grant_event(1, ALICE)], is_member=False)
+
+        assert manager.get_all_role_accounts() == []
+
+    def test_execution_delay_passthrough(self):
+        manager = _manager_with([_grant_event(1, ALICE)], execution_delay=3600)
+
+        (account,) = manager.get_all_role_accounts()
+
+        assert account.execution_delay == 3600
+
+    def test_deduplicates_repeated_grants(self):
+        # A re-granted (role, account) emits two RoleGranted events but is one
+        # current membership.
+        manager = _manager_with([_grant_event(1, ALICE), _grant_event(1, ALICE)])
+
+        accounts = manager.get_all_role_accounts()
+
+        assert len(accounts) == 1
+
+
+class TestGetAccountsWithRole:
+    def test_filters_by_role(self):
+        manager = _manager_with([_grant_event(1, ALICE), _grant_event(100, BOB)])
+
+        accounts = manager.get_accounts_with_role(100)
+
+        assert [(ra.role_id, ra.account) for ra in accounts] == [(100, BOB)]
+
+    def test_deduplicates_repeated_grants(self):
+        manager = _manager_with([_grant_event(100, BOB), _grant_event(100, BOB)])
+
+        assert len(manager.get_accounts_with_role(100)) == 1

--- a/tests/test_access_manager.py
+++ b/tests/test_access_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from eth_abi import encode
 from web3 import Web3
+from web3.exceptions import ContractLogicError
 
 # Top-level imports on purpose — they also exercise the __init__ exports.
 from ipor_fusion import (
@@ -98,6 +99,7 @@ class TestResolveAccessManager:
     @staticmethod
     def _ctx(bytecode: bytes = b"\x60\x80") -> MagicMock:
         ctx = MagicMock()
+        ctx.default_block = "latest"
         ctx.web3.eth.get_code.return_value = bytecode
         return ctx
 
@@ -107,12 +109,42 @@ class TestResolveAccessManager:
         with pytest.raises(ContractNotFoundError, match="No contract found"):
             resolve_access_manager(ctx, VAULT_ADDR)
 
-    def test_not_a_vault_raises(self):
+    def test_get_code_respects_pinned_block(self):
+        ctx = self._ctx(bytecode=b"")
+        ctx.default_block = 12345
+
+        with pytest.raises(ContractNotFoundError, match="at block 12345"):
+            resolve_access_manager(ctx, VAULT_ADDR)
+        ctx.web3.eth.get_code.assert_called_once_with(
+            VAULT_ADDR, block_identifier=12345
+        )
+
+    def test_empty_return_raises_not_a_vault(self):
+        # Fallback-bearing contracts answer the unknown selector with empty
+        # data; the real eth_abi decode raises InsufficientDataBytes.
         ctx = self._ctx()
-        ctx.call.side_effect = Exception("Tried to read 32 bytes, only got 0 bytes.")
+        ctx.call.return_value = b""
 
         with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
             resolve_access_manager(ctx, VAULT_ADDR)
+
+    def test_revert_raises_not_a_vault(self):
+        # Contracts without a fallback revert on the unknown selector.
+        ctx = self._ctx()
+        ctx.call.side_effect = ContractLogicError("execution reverted")
+
+        with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
+            resolve_access_manager(ctx, VAULT_ADDR)
+
+    def test_message_lookalike_propagates(self):
+        # Detection is typed, not string-matched: a generic exception whose
+        # text mimics the decode error must NOT be misclassified.
+        ctx = self._ctx()
+        ctx.call.side_effect = Exception("Tried to read 32 bytes, only got 0 bytes.")
+
+        with pytest.raises(Exception, match="Tried to read") as excinfo:
+            resolve_access_manager(ctx, VAULT_ADDR)
+        assert not isinstance(excinfo.value, NotAPlasmaVaultError)
 
     def test_other_errors_propagate_unchanged(self):
         ctx = self._ctx()

--- a/tests/test_access_manager.py
+++ b/tests/test_access_manager.py
@@ -2,12 +2,20 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from eth_abi import encode
 from web3 import Web3
 
-from ipor_fusion.core.access import AccessManager
+# Top-level imports on purpose — they also exercise the __init__ exports.
+from ipor_fusion import (
+    AccessManager,
+    ContractNotFoundError,
+    NotAPlasmaVaultError,
+    resolve_access_manager,
+)
 
 MANAGER_ADDR = Web3.to_checksum_address("0x1111111111111111111111111111111111111111")
+VAULT_ADDR = Web3.to_checksum_address("0x2222222222222222222222222222222222222222")
 ALICE = Web3.to_checksum_address("0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa")
 BOB = Web3.to_checksum_address("0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB")
 
@@ -84,3 +92,40 @@ class TestGetAccountsWithRole:
         manager = _manager_with([_grant_event(100, BOB), _grant_event(100, BOB)])
 
         assert len(manager.get_accounts_with_role(100)) == 1
+
+
+class TestResolveAccessManager:
+    @staticmethod
+    def _ctx(bytecode: bytes = b"\x60\x80") -> MagicMock:
+        ctx = MagicMock()
+        ctx.web3.eth.get_code.return_value = bytecode
+        return ctx
+
+    def test_no_contract_raises(self):
+        ctx = self._ctx(bytecode=b"")
+
+        with pytest.raises(ContractNotFoundError, match="No contract found"):
+            resolve_access_manager(ctx, VAULT_ADDR)
+
+    def test_not_a_vault_raises(self):
+        ctx = self._ctx()
+        ctx.call.side_effect = Exception("Tried to read 32 bytes, only got 0 bytes.")
+
+        with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
+            resolve_access_manager(ctx, VAULT_ADDR)
+
+    def test_other_errors_propagate_unchanged(self):
+        ctx = self._ctx()
+        ctx.call.side_effect = RuntimeError("rpc down")
+
+        with pytest.raises(RuntimeError, match="rpc down"):
+            resolve_access_manager(ctx, VAULT_ADDR)
+
+    def test_happy_path_returns_manager(self):
+        ctx = self._ctx()
+        ctx.call.return_value = encode(["address"], [MANAGER_ADDR])
+
+        manager = resolve_access_manager(ctx, VAULT_ADDR)
+
+        assert isinstance(manager, AccessManager)
+        assert manager.address == MANAGER_ADDR

--- a/tests/test_access_manager.py
+++ b/tests/test_access_manager.py
@@ -54,6 +54,14 @@ class TestGetAllRoleAccounts:
 
         assert account.execution_delay == 3600
 
+    def test_role_name_property(self):
+        manager = _manager_with([_grant_event(100, ALICE), _grant_event(1234, BOB)])
+
+        atomist, unknown = manager.get_all_role_accounts()
+
+        assert atomist.role_name == "ATOMIST_ROLE"
+        assert unknown.role_name == "UNKNOWN_ROLE_1234"
+
     def test_deduplicates_repeated_grants(self):
         # A re-granted (role, account) emits two RoleGranted events but is one
         # current membership.

--- a/tests/test_access_manager.py
+++ b/tests/test_access_manager.py
@@ -12,8 +12,11 @@ from ipor_fusion import (
     AccessManager,
     ContractNotFoundError,
     NotAPlasmaVaultError,
+    RoleAccount,
     resolve_access_manager,
+    role_account_sort_key,
 )
+from ipor_fusion.types import Period, RoleId
 
 MANAGER_ADDR = Web3.to_checksum_address("0x1111111111111111111111111111111111111111")
 VAULT_ADDR = Web3.to_checksum_address("0x2222222222222222222222222222222222222222")
@@ -93,6 +96,41 @@ class TestGetAccountsWithRole:
         manager = _manager_with([_grant_event(100, BOB), _grant_event(100, BOB)])
 
         assert len(manager.get_accounts_with_role(100)) == 1
+
+
+class TestRoleAccountHelpers:
+    @staticmethod
+    def _role_account(role_id: int, account: str, delay: int = 0) -> RoleAccount:
+        return RoleAccount(
+            account=account,  # type: ignore[arg-type]
+            role_id=RoleId(role_id),
+            is_member=True,
+            execution_delay=Period(delay),
+        )
+
+    def test_to_dict_is_the_canonical_row(self):
+        assert self._role_account(100, ALICE, delay=60).to_dict() == {
+            "account": ALICE,
+            "role_id": 100,
+            "role_name": "ATOMIST_ROLE",
+            "is_member": True,
+            "execution_delay": 60,
+        }
+
+    def test_sort_key_is_case_insensitive_then_by_role(self):
+        accounts = [
+            self._role_account(1, "0xBBBB"),
+            self._role_account(2, "0xaaaa"),
+            self._role_account(1, "0xaaaa"),
+        ]
+
+        ordered = sorted(accounts, key=role_account_sort_key)
+
+        assert [(ra.account, ra.role_id) for ra in ordered] == [
+            ("0xaaaa", 1),
+            ("0xaaaa", 2),
+            ("0xBBBB", 1),
+        ]
 
 
 class TestResolveAccessManager:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -10,6 +10,7 @@ from ipor_fusion.cli import config_store
 from ipor_fusion.cli.config_store import FusionConfig, VaultEntry, save_config
 from ipor_fusion.cli.main import cli, main
 from ipor_fusion.core.withdraw_manager import AccountRequest
+from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
 
 ADDR_1 = "0x1111111111111111111111111111111111111111"
 ADDR_2 = "0x2222222222222222222222222222222222222222"
@@ -244,7 +245,87 @@ class TestVaultRemove:
         assert "Vault not found" in result.output
 
 
+class TestVaultInfoGuards:
+    @staticmethod
+    def _setup(mock_ctx_cls) -> None:
+        save_config(FusionConfig(providers={"1": "https://rpc.example.com"}))
+        mock_ctx_cls.from_url.return_value = MagicMock()
+
+    @patch(
+        "ipor_fusion.cli.vault_cmd.resolve_access_manager",
+        side_effect=ContractNotFoundError(
+            f"No contract deployed at {ADDR_1} (as of block 123)."
+        ),
+    )
+    @patch("ipor_fusion.cli.vault_cmd.Web3Context")
+    def test_no_contract_is_usage_error(self, mock_ctx_cls, _resolve, tmp_config):
+        self._setup(mock_ctx_cls)
+
+        result = CliRunner().invoke(
+            cli,
+            ["vault", "info", ADDR_1, "--chain-id", "1", "--block-number", "123"],
+        )
+
+        assert result.exit_code != 0
+        assert "No contract deployed" in result.output
+        assert "as of block 123" in result.output
+        assert "Traceback" not in result.output
+
+    @patch(
+        "ipor_fusion.cli.vault_cmd.resolve_access_manager",
+        side_effect=NotAPlasmaVaultError(
+            f"{ADDR_1} does not appear to be a Plasma Vault."
+        ),
+    )
+    @patch("ipor_fusion.cli.vault_cmd.Web3Context")
+    def test_not_a_vault_is_usage_error(self, mock_ctx_cls, _resolve, tmp_config):
+        self._setup(mock_ctx_cls)
+
+        result = CliRunner().invoke(cli, ["vault", "info", ADDR_1, "--chain-id", "1"])
+
+        assert result.exit_code != 0
+        assert "does not appear to be a Plasma Vault" in result.output
+        assert "Traceback" not in result.output
+
+    @patch(
+        "ipor_fusion.cli.vault_cmd.resolve_access_manager",
+        side_effect=NotAPlasmaVaultError("not a vault"),
+    )
+    @patch("ipor_fusion.cli.vault_cmd.Web3Context")
+    def test_probe_runs_before_auto_save(self, mock_ctx_cls, _resolve, tmp_config):
+        # Regression: `vault info <ERC20>` must not auto-save the token as a
+        # vault — the probe rejects it before _auto_save_vault runs.
+        self._setup(mock_ctx_cls)
+
+        result = CliRunner().invoke(cli, ["vault", "info", ADDR_1, "--chain-id", "1"])
+
+        assert result.exit_code != 0
+        cfg_data = json.loads(tmp_config[1].read_text(encoding="utf-8"))
+        assert cfg_data["vaults"] == []
+
+    @patch(
+        "ipor_fusion.cli.vault_cmd._fetch_vault_data",
+        side_effect=RuntimeError("sub-call failed"),
+    )
+    @patch("ipor_fusion.cli.vault_cmd.resolve_access_manager")
+    @patch("ipor_fusion.cli.vault_cmd.Web3Context")
+    def test_other_fetch_errors_not_misdiagnosed(
+        self, mock_ctx_cls, _resolve, _fetch, tmp_config
+    ):
+        self._setup(mock_ctx_cls)
+
+        result = CliRunner().invoke(cli, ["vault", "info", ADDR_1, "--chain-id", "1"])
+
+        assert result.exit_code != 0
+        assert "does not appear" not in result.output
+
+
 class TestVaultInfo:
+    @pytest.fixture(autouse=True)
+    def _pass_vault_probe(self):
+        with patch("ipor_fusion.cli.vault_cmd.resolve_access_manager"):
+            yield
+
     @patch("ipor_fusion.cli.vault_fetcher.WithdrawManager")
     @patch("ipor_fusion.cli.vault_cmd.get_contract_name", return_value="SomeFuse")
     @patch("ipor_fusion.cli.vault_fetcher.PriceOracleMiddleware")
@@ -707,6 +788,11 @@ class TestVaultListJson:
 
 
 class TestVaultInfoJson:
+    @pytest.fixture(autouse=True)
+    def _pass_vault_probe(self):
+        with patch("ipor_fusion.cli.vault_cmd.resolve_access_manager"):
+            yield
+
     @patch("ipor_fusion.cli.vault_fetcher._fetch_aave_positions", return_value=None)
     @patch("ipor_fusion.cli.vault_fetcher._fetch_morpho_positions", return_value=None)
     @patch("ipor_fusion.cli.vault_fetcher.WithdrawManager")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -821,6 +821,8 @@ class TestVaultInfoJson:
         assert data["total_assets"]["raw"] == 1000 * 10**18
         assert data["managers"]["access"] == ADDR_ACCESS
         assert data["managers"]["rewards"] == ADDR_REWARDS
+        # Builder emits role_accounts (empty — the mocked ctx has no grant logs).
+        assert data["role_accounts"] == []
         assert len(data["fuses"]) == 1
         assert data["fuses"][0]["contract"] == "SomeFuse"
         assert len(data["balance_fuses"]) == 1

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -11,6 +11,7 @@ from ipor_fusion.cli.config_store import FusionConfig, VaultEntry, save_config
 from ipor_fusion.cli.main import cli, main
 from ipor_fusion.core.withdraw_manager import AccountRequest
 from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
+from ipor_fusion.mcp.models import VaultInfoResponse
 
 ADDR_1 = "0x1111111111111111111111111111111111111111"
 ADDR_2 = "0x2222222222222222222222222222222222222222"
@@ -952,6 +953,14 @@ class TestVaultInfoJson:
         assert len(wmd["pending_requests"]) == 1
         assert wmd["pending_requests"][0]["account"] == ADDR_USER_1
         assert wmd["pending_requests"][0]["can_withdraw"] is True
+
+        # Producer↔model contract check:
+        # - VaultInfoResponse (extra="forbid") must accept the real
+        #   _build_json_output dict verbatim.
+        # - lives here: only this rig runs the real producer (MCP tests mock it away)
+        # - on failure: declare the field in mcp/models.py, update the
+        #   test_mcp_models.py sample — don't loosen the model
+        VaultInfoResponse.model_validate(data)
 
     @patch(
         "ipor_fusion.cli.vault_fetcher.get_deployment_tx",

--- a/tests/test_cli_role_accounts.py
+++ b/tests/test_cli_role_accounts.py
@@ -4,12 +4,16 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from click.testing import CliRunner
+from web3.exceptions import Web3RPCError
 
 from ipor_fusion.cli import config_store
 from ipor_fusion.cli.config_store import FusionConfig, save_config
 from ipor_fusion.cli.main import cli
+from ipor_fusion.cli.vault_cmd import _fetch_role_accounts_json
 from ipor_fusion.core.access import RoleAccount
+from ipor_fusion.errors import NotAPlasmaVaultError
 from ipor_fusion.types import Period, RoleId
 
 VAULT = "0x2222222222222222222222222222222222222222"
@@ -104,7 +108,9 @@ class TestRoleAccounts:
         manager.get_all_role_accounts.assert_not_called()
         assert json.loads(result.output)["role_filter"] == "ATOMIST_ROLE"
 
-    def test_unknown_role_is_usage_error(self, _ctx, mock_resolve, tmp_config):
+    def test_unknown_role_is_usage_error_before_rpc(
+        self, mock_ctx_cls, mock_resolve, tmp_config
+    ):
         result = CliRunner().invoke(
             cli,
             ["vault", "role-accounts", VAULT, "--chain-id", "1", "--role", "bishop"],
@@ -112,9 +118,81 @@ class TestRoleAccounts:
 
         assert result.exit_code != 0
         assert "Valid: ADMIN_ROLE" in result.output
+        # Pure input validation must not need a provider.
+        mock_ctx_cls.from_url.assert_not_called()
+        mock_resolve.assert_not_called()
 
     def test_unknown_vault_needs_chain_id(self, _ctx, mock_resolve, tmp_config):
         result = CliRunner().invoke(cli, ["vault", "role-accounts", VAULT])
 
         assert result.exit_code != 0
         assert "--chain-id" in result.output
+
+    def test_not_a_vault_is_usage_error(self, _ctx, mock_resolve, tmp_config):
+        mock_resolve.side_effect = NotAPlasmaVaultError("not a Plasma Vault")
+
+        result = CliRunner().invoke(
+            cli, ["vault", "role-accounts", VAULT, "--chain-id", "1"]
+        )
+
+        assert result.exit_code != 0
+        assert "not a Plasma Vault" in result.output
+
+    def test_scan_rejection_is_friendly_error(self, _ctx, mock_resolve, tmp_config):
+        manager = _mock_manager([])
+        manager.get_all_role_accounts.side_effect = Web3RPCError(
+            "query returned more than 10000 results"
+        )
+        mock_resolve.return_value = manager
+
+        result = CliRunner().invoke(
+            cli, ["vault", "role-accounts", VAULT, "--chain-id", "1"]
+        )
+
+        assert result.exit_code != 0
+        assert "eth_getLogs" in result.output
+        assert "Traceback" not in result.output
+
+    def test_scan_transport_failure_is_friendly_error(
+        self, _ctx, mock_resolve, tmp_config
+    ):
+        manager = _mock_manager([])
+        manager.get_all_role_accounts.side_effect = requests.exceptions.ReadTimeout(
+            "provider timed out"
+        )
+        mock_resolve.return_value = manager
+
+        result = CliRunner().invoke(
+            cli, ["vault", "role-accounts", VAULT, "--chain-id", "1"]
+        )
+
+        assert result.exit_code != 0
+        assert "eth_getLogs" in result.output
+        assert "Traceback" not in result.output
+
+
+class TestFetchRoleAccountsJson:
+    @staticmethod
+    def _data() -> MagicMock:
+        data = MagicMock()
+        data.access_manager = MANAGER
+        return data
+
+    def test_transport_failure_degrades_to_none(self):
+        ctx = MagicMock()
+        ctx.get_logs.side_effect = requests.exceptions.ReadTimeout("timed out")
+
+        assert _fetch_role_accounts_json(ctx, self._data()) is None
+
+    def test_rpc_rejection_degrades_to_none(self):
+        ctx = MagicMock()
+        ctx.get_logs.side_effect = Web3RPCError("log range too large")
+
+        assert _fetch_role_accounts_json(ctx, self._data()) is None
+
+    def test_unexpected_errors_propagate(self):
+        ctx = MagicMock()
+        ctx.get_logs.side_effect = RuntimeError("bug, not a provider issue")
+
+        with pytest.raises(RuntimeError, match="bug"):
+            _fetch_role_accounts_json(ctx, self._data())

--- a/tests/test_cli_role_accounts.py
+++ b/tests/test_cli_role_accounts.py
@@ -1,0 +1,120 @@
+"""Tests for the `vault role-accounts` CLI command."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from ipor_fusion.cli import config_store
+from ipor_fusion.cli.config_store import FusionConfig, save_config
+from ipor_fusion.cli.main import cli
+from ipor_fusion.core.access import RoleAccount
+from ipor_fusion.types import Period, RoleId
+
+VAULT = "0x2222222222222222222222222222222222222222"
+MANAGER = "0x5555555555555555555555555555555555555555"
+ALICE = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+BOB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+@pytest.fixture
+def tmp_config(tmp_path, monkeypatch):
+    config_dir = tmp_path / ".fusion"
+    monkeypatch.setattr(config_store, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(config_store, "CONFIG_FILE", config_dir / "config.json")
+    save_config(FusionConfig(providers={"1": "https://rpc.example.com"}))
+
+
+def _role_account(role_id: int, account: str, delay: int = 0) -> RoleAccount:
+    return RoleAccount(
+        account=account,  # type: ignore[arg-type]
+        role_id=RoleId(role_id),
+        is_member=True,
+        execution_delay=Period(delay),
+    )
+
+
+def _mock_manager(accounts: list[RoleAccount]) -> MagicMock:
+    manager = MagicMock()
+    manager.address = MANAGER
+    manager.get_all_role_accounts.return_value = accounts
+    manager.get_accounts_with_role.return_value = accounts
+    return manager
+
+
+@patch("ipor_fusion.cli.vault_cmd.resolve_access_manager")
+@patch("ipor_fusion.cli.vault_cmd.Web3Context")
+class TestRoleAccounts:
+    def test_table_output(self, _ctx, mock_resolve, tmp_config):
+        mock_resolve.return_value = _mock_manager(
+            [_role_account(100, BOB), _role_account(1, ALICE, delay=60)]
+        )
+
+        result = CliRunner().invoke(
+            cli, ["vault", "role-accounts", VAULT, "--chain-id", "1"]
+        )
+
+        assert result.exit_code == 0
+        assert MANAGER in result.output
+        assert "OWNER_ROLE" in result.output
+        assert "ATOMIST_ROLE" in result.output
+
+    def test_json_output_sorted(self, _ctx, mock_resolve, tmp_config):
+        mock_resolve.return_value = _mock_manager(
+            [_role_account(100, BOB), _role_account(1, ALICE, delay=60)]
+        )
+
+        result = CliRunner().invoke(
+            cli, ["vault", "role-accounts", VAULT, "--chain-id", "1", "--json"]
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["access_manager"] == MANAGER
+        assert payload["role_filter"] is None
+        # Sorted by (account.lower(), role_id).
+        assert [(a["account"], a["role_id"]) for a in payload["accounts"]] == [
+            (ALICE, 1),
+            (BOB, 100),
+        ]
+        assert payload["accounts"][0]["role_name"] == "OWNER_ROLE"
+        assert payload["accounts"][0]["execution_delay"] == 60
+
+    def test_role_filter(self, _ctx, mock_resolve, tmp_config):
+        manager = _mock_manager([_role_account(100, BOB)])
+        mock_resolve.return_value = manager
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "vault",
+                "role-accounts",
+                VAULT,
+                "--chain-id",
+                "1",
+                "--role",
+                "atomist",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        manager.get_accounts_with_role.assert_called_once_with(100)
+        manager.get_all_role_accounts.assert_not_called()
+        assert json.loads(result.output)["role_filter"] == "ATOMIST_ROLE"
+
+    def test_unknown_role_is_usage_error(self, _ctx, mock_resolve, tmp_config):
+        result = CliRunner().invoke(
+            cli,
+            ["vault", "role-accounts", VAULT, "--chain-id", "1", "--role", "bishop"],
+        )
+
+        assert result.exit_code != 0
+        assert "Valid: ADMIN_ROLE" in result.output
+
+    def test_unknown_vault_needs_chain_id(self, _ctx, mock_resolve, tmp_config):
+        result = CliRunner().invoke(cli, ["vault", "role-accounts", VAULT])
+
+        assert result.exit_code != 0
+        assert "--chain-id" in result.output

--- a/tests/test_mcp_models.py
+++ b/tests/test_mcp_models.py
@@ -276,66 +276,6 @@ class TestSimpleResponseContracts:
             {"address": "0xA", "label": "x", "chain": "base", "chain_id": 8453}
         )
 
-
-def _role_account(role_id: int, account: str, delay: int = 0) -> RoleAccount:
-    return RoleAccount(
-        account=account,  # type: ignore[arg-type]
-        role_id=RoleId(role_id),
-        is_member=True,
-        execution_delay=Period(delay),
-    )
-
-
-class TestRoleAccountsResponse:
-    def test_from_role_accounts_maps_and_sorts(self):
-        accounts = [
-            _role_account(100, "0xBBBB", delay=60),
-            _role_account(1, "0xaaaa"),
-            _role_account(2, "0xaaaa"),
-        ]
-
-        resp = RoleAccountsResponse.from_role_accounts(
-            accounts,
-            vault="0xVAULT",
-            access_manager="0xAM",
-            chain_id=1,
-            role_filter=None,
-        )
-
-        # Sorted by (account.lower(), role_id); role_name resolved via the enum.
-        assert [(e.account, e.role_id) for e in resp.accounts] == [
-            ("0xaaaa", 1),
-            ("0xaaaa", 2),
-            ("0xBBBB", 100),
-        ]
-        assert resp.accounts[2].role_name == "ATOMIST_ROLE"
-        assert resp.accounts[2].execution_delay == 60
-        assert resp.role_filter is None
-
-    def test_role_filter_echo(self):
-        resp = RoleAccountsResponse.from_role_accounts(
-            [],
-            vault="0xVAULT",
-            access_manager="0xAM",
-            chain_id=1,
-            role_filter="ATOMIST_ROLE",
-        )
-        assert resp.role_filter == "ATOMIST_ROLE"
-        assert resp.accounts == []
-
-    def test_rejects_unknown_field(self):
-        with pytest.raises(ValidationError):
-            RoleAccountsResponse.model_validate(
-                {
-                    "vault": "0xVAULT",
-                    "access_manager": "0xAM",
-                    "chain_id": 1,
-                    "role_filter": None,
-                    "accounts": [],
-                    "extra": "no",
-                }
-            )
-
     def test_morpho_blue_market_full_dict(self):
         d = {
             "market_id": "0x" + "ab" * 32,
@@ -542,3 +482,63 @@ class TestRoleAccountsResponse:
         }
         recon = Reconciliation.model_validate(d)
         assert recon.implied_market_total.usd is None
+
+
+def _role_account(role_id: int, account: str, delay: int = 0) -> RoleAccount:
+    return RoleAccount(
+        account=account,  # type: ignore[arg-type]
+        role_id=RoleId(role_id),
+        is_member=True,
+        execution_delay=Period(delay),
+    )
+
+
+class TestRoleAccountsResponse:
+    def test_from_role_accounts_maps_and_sorts(self):
+        accounts = [
+            _role_account(100, "0xBBBB", delay=60),
+            _role_account(1, "0xaaaa"),
+            _role_account(2, "0xaaaa"),
+        ]
+
+        resp = RoleAccountsResponse.from_role_accounts(
+            accounts,
+            vault="0xVAULT",
+            access_manager="0xAM",
+            chain_id=1,
+            role_filter=None,
+        )
+
+        # Sorted by (account.lower(), role_id); role_name resolved via the enum.
+        assert [(e.account, e.role_id) for e in resp.accounts] == [
+            ("0xaaaa", 1),
+            ("0xaaaa", 2),
+            ("0xBBBB", 100),
+        ]
+        assert resp.accounts[2].role_name == "ATOMIST_ROLE"
+        assert resp.accounts[2].execution_delay == 60
+        assert resp.role_filter is None
+
+    def test_role_filter_echo(self):
+        resp = RoleAccountsResponse.from_role_accounts(
+            [],
+            vault="0xVAULT",
+            access_manager="0xAM",
+            chain_id=1,
+            role_filter="ATOMIST_ROLE",
+        )
+        assert resp.role_filter == "ATOMIST_ROLE"
+        assert resp.accounts == []
+
+    def test_rejects_unknown_field(self):
+        with pytest.raises(ValidationError):
+            RoleAccountsResponse.model_validate(
+                {
+                    "vault": "0xVAULT",
+                    "access_manager": "0xAM",
+                    "chain_id": 1,
+                    "role_filter": None,
+                    "accounts": [],
+                    "extra": "no",
+                }
+            )

--- a/tests/test_mcp_models.py
+++ b/tests/test_mcp_models.py
@@ -189,7 +189,7 @@ def _full_vault_info_dict() -> dict:
             ],
             "worst_ltv_usage_percent": 58.1,
         },
-        "health_check": {"ok": True, "warnings": []},
+        "health_check": {"ok": True, "warnings": [], "criticals": []},
     }
 
 

--- a/tests/test_mcp_models.py
+++ b/tests/test_mcp_models.py
@@ -10,15 +10,18 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from ipor_fusion.core.access import RoleAccount
 from ipor_fusion.mcp.models import (
     Amount,
     ConfigShowResponse,
     MetaMorphoVaultResponse,
     MorphoBlueMarketResponse,
     Reconciliation,
+    RoleAccountsResponse,
     VaultInfoResponse,
     VaultListEntry,
 )
+from ipor_fusion.types import Period, RoleId
 
 
 def _amount(raw: int = 0, formatted: str = "0", usd: float | None = None) -> dict:
@@ -262,6 +265,66 @@ class TestSimpleResponseContracts:
         VaultListEntry.model_validate(
             {"address": "0xA", "label": "x", "chain": "base", "chain_id": 8453}
         )
+
+
+def _role_account(role_id: int, account: str, delay: int = 0) -> RoleAccount:
+    return RoleAccount(
+        account=account,  # type: ignore[arg-type]
+        role_id=RoleId(role_id),
+        is_member=True,
+        execution_delay=Period(delay),
+    )
+
+
+class TestRoleAccountsResponse:
+    def test_from_role_accounts_maps_and_sorts(self):
+        accounts = [
+            _role_account(100, "0xBBBB", delay=60),
+            _role_account(1, "0xaaaa"),
+            _role_account(2, "0xaaaa"),
+        ]
+
+        resp = RoleAccountsResponse.from_role_accounts(
+            accounts,
+            vault="0xVAULT",
+            access_manager="0xAM",
+            chain_id=1,
+            role_filter=None,
+        )
+
+        # Sorted by (account.lower(), role_id); role_name resolved via the enum.
+        assert [(e.account, e.role_id) for e in resp.accounts] == [
+            ("0xaaaa", 1),
+            ("0xaaaa", 2),
+            ("0xBBBB", 100),
+        ]
+        assert resp.accounts[2].role_name == "ATOMIST_ROLE"
+        assert resp.accounts[2].execution_delay == 60
+        assert resp.role_filter is None
+
+    def test_role_filter_echo(self):
+        resp = RoleAccountsResponse.from_role_accounts(
+            [],
+            vault="0xVAULT",
+            access_manager="0xAM",
+            chain_id=1,
+            role_filter="ATOMIST_ROLE",
+        )
+        assert resp.role_filter == "ATOMIST_ROLE"
+        assert resp.accounts == []
+
+    def test_rejects_unknown_field(self):
+        with pytest.raises(ValidationError):
+            RoleAccountsResponse.model_validate(
+                {
+                    "vault": "0xVAULT",
+                    "access_manager": "0xAM",
+                    "chain_id": 1,
+                    "role_filter": None,
+                    "accounts": [],
+                    "extra": "no",
+                }
+            )
 
     def test_morpho_blue_market_full_dict(self):
         d = {

--- a/tests/test_mcp_models.py
+++ b/tests/test_mcp_models.py
@@ -31,9 +31,11 @@ def _amount(raw: int = 0, formatted: str = "0", usd: float | None = None) -> dic
 def _full_vault_info_dict() -> dict:
     """Mirror of cli/vault_cmd.py::_build_json_output with every optional
     block populated (lending positions, withdraw manager, substrates with
-    address+symbol+contract, balance fuses with both Morpho and Aave
-    position breakdowns, ERC20 with full token detail). Keep in sync with
-    the dict literal at the bottom of _build_json_output."""
+    address+symbol+contract, fuses with optional market info, balance fuses
+    with both Morpho and Aave position breakdowns, ERC20 with full token
+    detail). Keep in sync with the dict literal at the bottom of
+    _build_json_output — the sync itself is enforced by the producer contract
+    check in test_cli_commands.py::TestVaultInfoJson::test_json_output."""
     return {
         "vault": "0xVAULT",
         "name": "Test Vault",
@@ -81,7 +83,14 @@ def _full_vault_info_dict() -> dict:
             "pending_requests": [],
         },
         "fuses": [
-            {"address": "0xFUSE1", "contract": "MorphoSupplyFuse"},
+            {
+                "address": "0xFUSE1",
+                "contract": "MorphoSupplyFuse",
+                "market_id": 1,
+                "market": "MORPHO",
+            },
+            # market_id/market are omitted (not None) for market-less fuses.
+            {"address": "0xFUSE2", "contract": "UniversalTokenSwapperFuse"},
         ],
         "balance_fuses": [
             {
@@ -139,7 +148,12 @@ def _full_vault_info_dict() -> dict:
             },
         ],
         "instant_withdrawal_fuses": [
-            {"address": "0xIW1", "contract": "ERC4626SupplyFuse"},
+            {
+                "address": "0xIW1",
+                "contract": "ERC4626SupplyFuse",
+                "market_id": 5,
+                "market": "ERC4626",
+            },
         ],
         "substrates": {
             "MORPHO (1)": [
@@ -201,7 +215,12 @@ def _full_vault_info_dict() -> dict:
                 "execution_delay": 0,
             }
         ],
-        "health_check": {"ok": True, "warnings": [], "criticals": []},
+        # `ok` is a list of passing-check lines, not a boolean.
+        "health_check": {
+            "ok": ["morpho WETH/USDC: LTV 0.50/0.86, health_factor=1.72"],
+            "warnings": [],
+            "criticals": [],
+        },
     }
 
 
@@ -213,6 +232,12 @@ class TestVaultInfoResponseContract:
         assert result.zero_balance_fuses[0].contract == "ZeroBalanceFuse"
         assert result.lending_health is not None
         assert result.reconciliation.delta.percent == 0.0
+        assert result.fuses[0].market_id == 1
+        assert result.fuses[0].market == "MORPHO"
+        assert result.fuses[1].market_id is None
+        assert result.health_check.ok == [
+            "morpho WETH/USDC: LTV 0.50/0.86, health_factor=1.72"
+        ]
 
     def test_minimal_dict_validates(self):
         """All optional sections set to None/empty."""

--- a/tests/test_mcp_models.py
+++ b/tests/test_mcp_models.py
@@ -192,6 +192,15 @@ def _full_vault_info_dict() -> dict:
             ],
             "worst_ltv_usage_percent": 58.1,
         },
+        "role_accounts": [
+            {
+                "account": "0xOWNER",
+                "role_id": 1,
+                "role_name": "OWNER_ROLE",
+                "is_member": True,
+                "execution_delay": 0,
+            }
+        ],
         "health_check": {"ok": True, "warnings": [], "criticals": []},
     }
 
@@ -214,6 +223,7 @@ class TestVaultInfoResponseContract:
         d["withdraw_manager_details"] = None
         d["dependency_graph"] = None
         d["lending_health"] = None
+        d["role_accounts"] = None
         d["balance_fuses"] = []
         d["substrates"] = {}
         d["erc20_balances"] = []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -143,6 +143,113 @@ class TestVaultRemove:
         assert "not found" in result.message.lower()
 
 
+# ── vault_role_accounts ───────────────────────────────────────────────
+
+
+import asyncio  # noqa: E402
+
+import pytest  # noqa: E402
+
+from ipor_fusion import NotAPlasmaVaultError, RoleAccount  # noqa: E402
+from ipor_fusion.mcp.server import mcp, vault_role_accounts  # noqa: E402
+from ipor_fusion.types import Period, RoleId  # noqa: E402
+
+VAULT_ADDR = "0x" + "22" * 20
+
+
+def _role_account(role_id: int, account: str, delay: int = 0) -> RoleAccount:
+    return RoleAccount(
+        account=account,  # type: ignore[arg-type]
+        role_id=RoleId(role_id),
+        is_member=True,
+        execution_delay=Period(delay),
+    )
+
+
+def _mock_manager(accounts: list[RoleAccount]) -> MagicMock:
+    manager = MagicMock()
+    manager.address = "0xAM"
+    manager.get_all_role_accounts.return_value = accounts
+    manager.get_accounts_with_role.return_value = accounts
+    return manager
+
+
+class TestVaultRoleAccounts:
+    @patch("ipor_fusion.mcp.server.resolve_access_manager")
+    @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_all_roles(self, _load, _ctx, mock_resolve):
+        manager = _mock_manager(
+            [_role_account(100, "0xBBBB"), _role_account(1, "0xaaaa", delay=60)]
+        )
+        mock_resolve.return_value = manager
+
+        result = vault_role_accounts(vault_address=VAULT_ADDR)
+
+        manager.get_all_role_accounts.assert_called_once()
+        manager.get_accounts_with_role.assert_not_called()
+        assert result.role_filter is None
+        assert result.access_manager == "0xAM"
+        assert result.chain_id == 1  # single-provider fallback
+        assert [
+            (e.account, e.role_id, e.role_name, e.execution_delay)
+            for e in result.accounts
+        ] == [
+            ("0xaaaa", 1, "OWNER_ROLE", 60),
+            ("0xBBBB", 100, "ATOMIST_ROLE", 0),
+        ]
+
+    @patch("ipor_fusion.mcp.server.resolve_access_manager")
+    @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_filtered_by_normalized_name(self, _load, _ctx, mock_resolve):
+        manager = _mock_manager([_role_account(100, "0xBBBB")])
+        mock_resolve.return_value = manager
+
+        result = vault_role_accounts(vault_address=VAULT_ADDR, role="atomist")
+
+        manager.get_accounts_with_role.assert_called_once_with(100)
+        manager.get_all_role_accounts.assert_not_called()
+        assert result.role_filter == "ATOMIST_ROLE"
+
+    @patch("ipor_fusion.mcp.server._build_ctx")
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_unknown_role_fails_before_rpc(self, _load, mock_ctx):
+        with pytest.raises(ValueError, match="Valid: ADMIN_ROLE"):
+            vault_role_accounts(vault_address=VAULT_ADDR, role="archbishop")
+        mock_ctx.assert_not_called()
+
+    @patch(
+        "ipor_fusion.mcp.server.resolve_access_manager",
+        side_effect=NotAPlasmaVaultError("not a vault"),
+    )
+    @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_guard_errors_propagate(self, _load, _ctx, _resolve):
+        with pytest.raises(NotAPlasmaVaultError, match="not a vault"):
+            vault_role_accounts(vault_address=VAULT_ADDR)
+
+    def test_description_lists_roles(self):
+        # Verifies description= reached FastMCP and guards role-list drift.
+        tools = asyncio.run(mcp.list_tools())
+        tool = next(t for t in tools if t.name == "vault_role_accounts")
+        assert tool.description is not None
+        assert "ATOMIST_ROLE" in tool.description
+        assert "PUBLIC_ROLE" in tool.description
+
+
 # ── market tools ──────────────────────────────────────────────────────
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,15 +1,47 @@
 """Tests for the MCP server tool definitions (direct SDK import)."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
+import pytest
+from eth_abi.exceptions import InsufficientDataBytes
+from web3 import Web3
+
+from ipor_fusion import (
+    ContractNotFoundError,
+    NotAPlasmaVaultError,
+    RoleAccount,
+)
+from ipor_fusion.cli.morpho_api import (
+    MorphoApiError,
+    MorphoApiMarket,
+    VaultAllocation,
+    VaultFlowCap,
+    VaultV1Info,
+    VaultV1MarketAllocation,
+    VaultV2Adapter,
+    VaultV2Cap,
+    VaultV2Info,
+)
 from ipor_fusion.mcp.server import (
     config_set_etherscan_key,
     config_set_provider,
     config_show,
+    market_meta_morpho,
+    market_morpho_blue,
+    mcp,
     vault_add,
+    vault_info,
     vault_list,
     vault_remove,
+    vault_role_accounts,
 )
+from ipor_fusion.readers.morpho import (
+    MorphoMarket,
+    MorphoMarketParams,
+    MorphoMarketRates,
+)
+from ipor_fusion.types import Period, RoleId
 
 
 def _empty_config():
@@ -145,20 +177,6 @@ class TestVaultRemove:
 
 # ── vault_role_accounts ───────────────────────────────────────────────
 
-
-import asyncio  # noqa: E402
-
-import pytest  # noqa: E402
-from eth_abi.exceptions import InsufficientDataBytes  # noqa: E402
-from web3 import Web3  # noqa: E402
-
-from ipor_fusion import (  # noqa: E402
-    ContractNotFoundError,
-    NotAPlasmaVaultError,
-    RoleAccount,
-)
-from ipor_fusion.mcp.server import mcp, vault_info, vault_role_accounts  # noqa: E402
-from ipor_fusion.types import Period, RoleId  # noqa: E402
 
 VAULT_ADDR = "0x" + "22" * 20
 
@@ -311,27 +329,6 @@ class TestVaultInfoGuards:
 
 # ── market tools ──────────────────────────────────────────────────────
 
-
-from ipor_fusion.cli.morpho_api import (  # noqa: E402
-    MorphoApiError,
-    MorphoApiMarket,
-    VaultAllocation,
-    VaultFlowCap,
-    VaultV1Info,
-    VaultV1MarketAllocation,
-    VaultV2Adapter,
-    VaultV2Cap,
-    VaultV2Info,
-)
-from ipor_fusion.mcp.server import (  # noqa: E402
-    market_meta_morpho,
-    market_morpho_blue,
-)
-from ipor_fusion.readers.morpho import (  # noqa: E402
-    MorphoMarket,
-    MorphoMarketParams,
-    MorphoMarketRates,
-)
 
 _MARKET_ID = "ad656d430bb3d8c1469bf45c8ad4ebae1b04be04757c69fa424eec78d7b3f4dc"
 _LOAN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,7 +4,6 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-from eth_abi.exceptions import InsufficientDataBytes
 from web3 import Web3
 
 from ipor_fusion import (
@@ -275,39 +274,32 @@ class TestVaultRoleAccounts:
 
 
 class TestVaultInfoGuards:
-    @staticmethod
-    def _ctx(bytecode: bytes = b"\x60\x80") -> MagicMock:
-        ctx = MagicMock()
-        ctx.web3.eth.get_code.return_value = bytecode
-        return ctx
-
-    @patch("ipor_fusion.mcp.server._build_ctx")
+    @patch(
+        "ipor_fusion.mcp.server.resolve_access_manager",
+        side_effect=ContractNotFoundError("No contract found at 0x22... on chain 1."),
+    )
+    @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
     @patch(
         "ipor_fusion.mcp.server.load_config",
         return_value=_config_with_provider(),
     )
-    def test_no_contract_raises_typed(self, _load, mock_build_ctx):
-        ctx = self._ctx(bytecode=b"")
-        mock_build_ctx.return_value = (ctx, None)
-
+    def test_no_contract_raises_typed(self, _load, _ctx, mock_resolve):
         with pytest.raises(ContractNotFoundError, match="No contract found"):
             vault_info(vault_address=VAULT_ADDR, chain_id=1)
-        ctx.web3.eth.get_code.assert_called_once_with(
-            Web3.to_checksum_address(VAULT_ADDR), block_identifier=ctx.default_block
-        )
+        # The probe receives the checksummed address.
+        mock_resolve.assert_called_once()
+        assert mock_resolve.call_args.args[1] == Web3.to_checksum_address(VAULT_ADDR)
 
     @patch(
-        "ipor_fusion.mcp.server._fetch_vault_data",
-        side_effect=InsufficientDataBytes("Tried to read 32 bytes, only got 0 bytes."),
+        "ipor_fusion.mcp.server.resolve_access_manager",
+        side_effect=NotAPlasmaVaultError("does not appear to be a Plasma Vault"),
     )
-    @patch("ipor_fusion.mcp.server._build_ctx")
+    @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
     @patch(
         "ipor_fusion.mcp.server.load_config",
         return_value=_config_with_provider(),
     )
-    def test_empty_decode_raises_not_a_vault(self, _load, mock_build_ctx, _fetch):
-        mock_build_ctx.return_value = (self._ctx(), None)
-
+    def test_not_a_vault_raises_typed(self, _load, _ctx, _resolve):
         with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
             vault_info(vault_address=VAULT_ADDR, chain_id=1)
 
@@ -315,14 +307,13 @@ class TestVaultInfoGuards:
         "ipor_fusion.mcp.server._fetch_vault_data",
         side_effect=RuntimeError("some sub-call failed"),
     )
-    @patch("ipor_fusion.mcp.server._build_ctx")
+    @patch("ipor_fusion.mcp.server.resolve_access_manager")
+    @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
     @patch(
         "ipor_fusion.mcp.server.load_config",
         return_value=_config_with_provider(),
     )
-    def test_other_fetch_errors_propagate(self, _load, mock_build_ctx, _fetch):
-        mock_build_ctx.return_value = (self._ctx(), None)
-
+    def test_other_fetch_errors_propagate(self, _load, _ctx, _resolve, _fetch):
         with pytest.raises(RuntimeError, match="some sub-call failed"):
             vault_info(vault_address=VAULT_ADDR, chain_id=1)
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -149,9 +149,15 @@ class TestVaultRemove:
 import asyncio  # noqa: E402
 
 import pytest  # noqa: E402
+from eth_abi.exceptions import InsufficientDataBytes  # noqa: E402
+from web3 import Web3  # noqa: E402
 
-from ipor_fusion import NotAPlasmaVaultError, RoleAccount  # noqa: E402
-from ipor_fusion.mcp.server import mcp, vault_role_accounts  # noqa: E402
+from ipor_fusion import (  # noqa: E402
+    ContractNotFoundError,
+    NotAPlasmaVaultError,
+    RoleAccount,
+)
+from ipor_fusion.mcp.server import mcp, vault_info, vault_role_accounts  # noqa: E402
 from ipor_fusion.types import Period, RoleId  # noqa: E402
 
 VAULT_ADDR = "0x" + "22" * 20
@@ -248,6 +254,59 @@ class TestVaultRoleAccounts:
         assert tool.description is not None
         assert "ATOMIST_ROLE" in tool.description
         assert "PUBLIC_ROLE" in tool.description
+
+
+class TestVaultInfoGuards:
+    @staticmethod
+    def _ctx(bytecode: bytes = b"\x60\x80") -> MagicMock:
+        ctx = MagicMock()
+        ctx.web3.eth.get_code.return_value = bytecode
+        return ctx
+
+    @patch("ipor_fusion.mcp.server._build_ctx")
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_no_contract_raises_typed(self, _load, mock_build_ctx):
+        ctx = self._ctx(bytecode=b"")
+        mock_build_ctx.return_value = (ctx, None)
+
+        with pytest.raises(ContractNotFoundError, match="No contract found"):
+            vault_info(vault_address=VAULT_ADDR, chain_id=1)
+        ctx.web3.eth.get_code.assert_called_once_with(
+            Web3.to_checksum_address(VAULT_ADDR), block_identifier=ctx.default_block
+        )
+
+    @patch(
+        "ipor_fusion.mcp.server._fetch_vault_data",
+        side_effect=InsufficientDataBytes("Tried to read 32 bytes, only got 0 bytes."),
+    )
+    @patch("ipor_fusion.mcp.server._build_ctx")
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_empty_decode_raises_not_a_vault(self, _load, mock_build_ctx, _fetch):
+        mock_build_ctx.return_value = (self._ctx(), None)
+
+        with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
+            vault_info(vault_address=VAULT_ADDR, chain_id=1)
+
+    @patch(
+        "ipor_fusion.mcp.server._fetch_vault_data",
+        side_effect=RuntimeError("some sub-call failed"),
+    )
+    @patch("ipor_fusion.mcp.server._build_ctx")
+    @patch(
+        "ipor_fusion.mcp.server.load_config",
+        return_value=_config_with_provider(),
+    )
+    def test_other_fetch_errors_propagate(self, _load, mock_build_ctx, _fetch):
+        mock_build_ctx.return_value = (self._ctx(), None)
+
+        with pytest.raises(RuntimeError, match="some sub-call failed"):
+            vault_info(vault_address=VAULT_ADDR, chain_id=1)
 
 
 # ── market tools ──────────────────────────────────────────────────────

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,57 @@
+"""Unit tests for the Roles enum helpers (resolve / names_str / get_name)."""
+
+import pytest
+
+from ipor_fusion.config.roles import Roles
+
+
+class TestResolve:
+    def test_canonical_name(self):
+        assert Roles.resolve("ATOMIST_ROLE") == 100
+
+    def test_case_insensitive(self):
+        assert Roles.resolve("atomist_role") == 100
+        assert Roles.resolve("Atomist") == 100
+
+    def test_suffix_optional(self):
+        assert Roles.resolve("owner") == 1
+        assert Roles.resolve("OWNER") == 1
+
+    def test_spaces_and_hyphens(self):
+        assert Roles.resolve("ipor dao") == 4
+        assert Roles.resolve("fuse-manager") == 300
+        assert Roles.resolve("Ipor Dao Role") == 4
+
+    def test_admin_is_zero(self):
+        # 0 is a valid id — resolution must not treat it as falsy anywhere.
+        assert Roles.resolve("admin") == 0
+
+    def test_unknown_lists_valid_names(self):
+        with pytest.raises(ValueError, match="Valid: ADMIN_ROLE"):
+            Roles.resolve("archbishop")
+
+    def test_near_miss_suggests(self):
+        with pytest.raises(ValueError, match="Did you mean ATOMIST_ROLE"):
+            Roles.resolve("atomsit")
+
+    def test_blank_raises(self):
+        with pytest.raises(ValueError, match="Unknown role ''"):
+            Roles.resolve("")
+
+
+class TestNamesStr:
+    def test_contains_every_member(self):
+        names_str = Roles.names_str()
+        for role in Roles:
+            assert role.name in names_str
+
+    def test_comma_separated(self):
+        assert Roles.names_str().startswith("ADMIN_ROLE, OWNER_ROLE")
+
+
+class TestGetName:
+    def test_known(self):
+        assert Roles.get_name(100) == "ATOMIST_ROLE"
+
+    def test_unknown_fallback(self):
+        assert Roles.get_name(1234) == "UNKNOWN_ROLE_1234"


### PR DESCRIPTION
## Role accounts + typed vault guards

Adds role-account visibility across SDK/CLI/MCP and typed guards for
non-vault targets; fixes MCP response-model drift found while testing.

### Role accounts
- SDK: `AccessManager.get_all_role_accounts` / `get_accounts_with_role`,
  `RoleAccount.role_name`, dedup by `(role_id, account)`
- CLI: `vault role-accounts` command; role accounts included in `vault info`
  (fetched concurrently with the rest)
- MCP: `vault_role_accounts` tool + models

### Typed guards
- SDK: `resolve_access_manager` probe raises `ContractNotFoundError` /
  `NotAPlasmaVaultError` (both revert and empty-return flavors),
  block-consistent
- CLI: clean usage errors; probe runs before vault auto-save (no more
  config pollution from `vault info <ERC20>`)
- MCP: typed errors propagate unwrapped

### Model sync
- `VaultInfoResponse` caught up with the producer (`FuseEntry.market_id`/
  `market`, `health_check.ok` as `list[str]`); `vault info --json` output
  is now validated against the MCP model as a producer contract test