### PR TITLE
Feat/vault role accounts

### DIFF
--- a/src/ipor_fusion/__init__.py
+++ b/src/ipor_fusion/__init__.py
@@ -28,7 +28,7 @@ from ipor_fusion.core.withdraw_manager import (
 from ipor_fusion.errors import (
     ContractNotFoundError,
     IporFusionError,
-    NotAPlasmaVaultError,
+    NotPlasmaVaultError,
     TransactionError,
 )
 from ipor_fusion.fuses import (
@@ -186,7 +186,7 @@ __all__ = [
     "IporFusionMarkets",
     "ContractNotFoundError",
     "IporFusionError",
-    "NotAPlasmaVaultError",
+    "NotPlasmaVaultError",
     "TransactionError",
     "Amount",
     "Shares",

--- a/src/ipor_fusion/cli/vault_cmd.py
+++ b/src/ipor_fusion/cli/vault_cmd.py
@@ -56,7 +56,7 @@ from ipor_fusion.core.access import (
 )
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
-from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
+from ipor_fusion.errors import ContractNotFoundError, NotPlasmaVaultError
 
 
 class AddressType(click.ParamType):
@@ -358,7 +358,7 @@ def info(
     # expensive fetch — and before auto-save can store a non-vault.
     try:
         resolve_access_manager(ctx, vault_address)
-    except (ContractNotFoundError, NotAPlasmaVaultError) as exc:
+    except (ContractNotFoundError, NotPlasmaVaultError) as exc:
         raise click.UsageError(str(exc)) from exc
 
     plasma_vault = PlasmaVault(ctx, checksum_address)
@@ -410,7 +410,7 @@ def role_accounts(
 
     try:
         manager = resolve_access_manager(ctx, vault_address)
-    except (ContractNotFoundError, NotAPlasmaVaultError) as exc:
+    except (ContractNotFoundError, NotPlasmaVaultError) as exc:
         raise click.UsageError(str(exc)) from exc
 
     try:

--- a/src/ipor_fusion/core/access.py
+++ b/src/ipor_fusion/core/access.py
@@ -13,7 +13,7 @@ from ipor_fusion.config.roles import Roles
 from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.contract import Call, ContractWrapper
 from ipor_fusion.core.plasma_vault import PlasmaVault
-from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
+from ipor_fusion.errors import ContractNotFoundError, NotPlasmaVaultError
 from ipor_fusion.types import Period, RoleId
 
 
@@ -156,7 +156,7 @@ def resolve_access_manager(
     """Resolve a vault address to its AccessManager, with typed guards.
 
     Raises ContractNotFoundError when no code is deployed at the address (as
-    of ctx.default_block), and NotAPlasmaVaultError when the contract does not
+    of ctx.default_block), and NotPlasmaVaultError when the contract does not
     expose getAccessManagerAddress() — either an empty eth_call return
     (InsufficientDataBytes on decode) or a revert (ContractLogicError).
     Provider/transport errors propagate unchanged.
@@ -175,7 +175,7 @@ def resolve_access_manager(
     try:
         manager_address = PlasmaVault(ctx, checksum).get_access_manager_address().call()
     except (InsufficientDataBytes, ContractLogicError) as exc:
-        raise NotAPlasmaVaultError(
+        raise NotPlasmaVaultError(
             f"Address {checksum} on chain {ctx.chain_id} does not appear "
             f"to be a Plasma Vault."
         ) from exc

--- a/src/ipor_fusion/errors.py
+++ b/src/ipor_fusion/errors.py
@@ -99,7 +99,7 @@ class ContractNotFoundError(IporFusionError, ValueError):
     """
 
 
-class NotAPlasmaVaultError(IporFusionError, ValueError):
+class NotPlasmaVaultError(IporFusionError, ValueError):
     """Contract exists but does not implement the Plasma Vault interface.
 
     Also a ValueError so MCP adapters can let it propagate unmapped.

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -4,7 +4,10 @@ Calls the ipor_fusion SDK directly — no CLI subprocess.
 Configuration is loaded from the shared CLI config (~/.config/ipor-fusion/).
 """
 
+from typing import Annotated, Literal
+
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 from web3 import Web3
 
 from ipor_fusion.cli.config_store import (
@@ -140,34 +143,56 @@ def vault_info(
     return VaultInfoResponse.model_validate(result)
 
 
-def _role_accounts_description() -> str:
-    # Generated (not a docstring) so the role list always matches the enum.
-    return (
-        "List confirmed role holders on a Plasma Vault's AccessManager.\n"
-        "Pass `role` to filter to one role — matching is case-insensitive and "
-        "the `_ROLE` suffix is optional; omit it (empty string) to list all "
-        "roles.\n"
-        f"Valid roles: {Roles.names_str()}.\n"
-        "TECH_* roles are held by protocol contracts, not EOAs — expect "
-        "contract addresses for those.\n"
-        "Cost: scans RoleGranted logs + one hasRole read per unique "
-        "(role, account) pair; can be slow on vaults with many grants and "
-        "needs a provider that serves broad eth_getLogs queries.\n"
-        "Returns: vault, access_manager, chain_id, role_filter (canonical "
-        "name or null), and accounts[] of {account, role_id, role_name, "
-        "is_member, execution_delay}."
-    )
+# Static mirror of Roles member names: pyright rejects a dynamically built
+# enum in annotations, so the drift guard lives in test_mcp_server.py.
+RoleName = Literal[
+    "ADMIN_ROLE",
+    "OWNER_ROLE",
+    "GUARDIAN_ROLE",
+    "TECH_PLASMA_VAULT_ROLE",
+    "IPOR_DAO_ROLE",
+    "TECH_CONTEXT_MANAGER_ROLE",
+    "TECH_WITHDRAW_MANAGER_ROLE",
+    "TECH_VAULT_TRANSFER_SHARES_ROLE",
+    "ATOMIST_ROLE",
+    "ALPHA_ROLE",
+    "FUSE_MANAGER_ROLE",
+    "PRE_HOOKS_MANAGER_ROLE",
+    "TECH_PERFORMANCE_FEE_MANAGER_ROLE",
+    "TECH_MANAGEMENT_FEE_MANAGER_ROLE",
+    "CLAIM_REWARDS_ROLE",
+    "TECH_REWARDS_CLAIM_MANAGER_ROLE",
+    "TRANSFER_REWARDS_ROLE",
+    "WHITELIST_ROLE",
+    "CONFIG_INSTANT_WITHDRAWAL_FUSES_ROLE",
+    "WITHDRAW_MANAGER_REQUEST_FEE_ROLE",
+    "WITHDRAW_MANAGER_WITHDRAW_FEE_ROLE",
+    "UPDATE_MARKETS_BALANCES_ROLE",
+    "UPDATE_REWARDS_BALANCE_ROLE",
+    "PRICE_ORACLE_MIDDLEWARE_MANAGER_ROLE",
+    "PUBLIC_ROLE",
+]
 
 
-@mcp.tool(description=_role_accounts_description())
+@mcp.tool()
 def vault_role_accounts(
-    vault_address: str,
-    role: str = "",
-    chain_id: int = 0,
-    block_number: int = 0,
+    vault_address: Annotated[str, Field(description="Plasma Vault address.")],
+    role: Annotated[
+        RoleName | None,
+        Field(description="Role to filter by; omit to list all roles."),
+    ] = None,
+    chain_id: Annotated[int, Field(description="Chain ID (auto-detected if 0).")] = 0,
+    block_number: Annotated[int, Field(description="Block number (latest if 0).")] = 0,
 ) -> RoleAccountsResponse:
+    """List confirmed role holders on a Plasma Vault's AccessManager.
+
+    TECH_* roles are held by protocol contracts, not EOAs.
+    Cost: scans RoleGranted logs + one hasRole read per unique
+    (role, account) pair; can be slow on vaults with many grants and
+    needs a provider that serves broad eth_getLogs queries.
+    """
     cfg = load_config()
-    role_id = None if not role.strip() else Roles.resolve(role)
+    role_id = None if role is None else Roles.resolve(role)
     chain_id = _resolve_chain_id(cfg, vault_address, chain_id)
     ctx, _ = _build_ctx(cfg, chain_id, block_number)
     checksum = Web3.to_checksum_address(vault_address)

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -117,7 +117,7 @@ def vault_info(
     checksum = Web3.to_checksum_address(vault_address)
 
     # Cheap single-call probe: raises the typed ContractNotFoundError /
-    # NotAPlasmaVaultError ("not a vault" in both revert and empty-return
+    # NotPlasmaVaultError ("not a vault" in both revert and empty-return
     # flavors) before the expensive fetch. The fetch itself stays catch-free:
     # once the probe passes, any later failure is a real error on a real
     # vault and must stay loud.

--- a/tests/test_access_manager.py
+++ b/tests/test_access_manager.py
@@ -11,7 +11,7 @@ from web3.exceptions import ContractLogicError
 from ipor_fusion import (
     AccessManager,
     ContractNotFoundError,
-    NotAPlasmaVaultError,
+    NotPlasmaVaultError,
     RoleAccount,
     resolve_access_manager,
     role_account_sort_key,
@@ -163,7 +163,7 @@ class TestResolveAccessManager:
         ctx = self._ctx()
         ctx.call.return_value = b""
 
-        with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
+        with pytest.raises(NotPlasmaVaultError, match="does not appear"):
             resolve_access_manager(ctx, VAULT_ADDR)
 
     def test_revert_raises_not_a_vault(self):
@@ -171,7 +171,7 @@ class TestResolveAccessManager:
         ctx = self._ctx()
         ctx.call.side_effect = ContractLogicError("execution reverted")
 
-        with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
+        with pytest.raises(NotPlasmaVaultError, match="does not appear"):
             resolve_access_manager(ctx, VAULT_ADDR)
 
     def test_message_lookalike_propagates(self):
@@ -182,7 +182,7 @@ class TestResolveAccessManager:
 
         with pytest.raises(Exception, match="Tried to read") as excinfo:
             resolve_access_manager(ctx, VAULT_ADDR)
-        assert not isinstance(excinfo.value, NotAPlasmaVaultError)
+        assert not isinstance(excinfo.value, NotPlasmaVaultError)
 
     def test_other_errors_propagate_unchanged(self):
         ctx = self._ctx()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -10,7 +10,7 @@ from ipor_fusion.cli import config_store
 from ipor_fusion.cli.config_store import FusionConfig, VaultEntry, save_config
 from ipor_fusion.cli.main import cli, main
 from ipor_fusion.core.withdraw_manager import AccountRequest
-from ipor_fusion.errors import ContractNotFoundError, NotAPlasmaVaultError
+from ipor_fusion.errors import ContractNotFoundError, NotPlasmaVaultError
 from ipor_fusion.mcp.models import VaultInfoResponse
 
 ADDR_1 = "0x1111111111111111111111111111111111111111"
@@ -274,7 +274,7 @@ class TestVaultInfoGuards:
 
     @patch(
         "ipor_fusion.cli.vault_cmd.resolve_access_manager",
-        side_effect=NotAPlasmaVaultError(
+        side_effect=NotPlasmaVaultError(
             f"{ADDR_1} does not appear to be a Plasma Vault."
         ),
     )
@@ -290,7 +290,7 @@ class TestVaultInfoGuards:
 
     @patch(
         "ipor_fusion.cli.vault_cmd.resolve_access_manager",
-        side_effect=NotAPlasmaVaultError("not a vault"),
+        side_effect=NotPlasmaVaultError("not a vault"),
     )
     @patch("ipor_fusion.cli.vault_cmd.Web3Context")
     def test_probe_runs_before_auto_save(self, mock_ctx_cls, _resolve, tmp_config):

--- a/tests/test_cli_role_accounts.py
+++ b/tests/test_cli_role_accounts.py
@@ -13,7 +13,7 @@ from ipor_fusion.cli.config_store import FusionConfig, save_config
 from ipor_fusion.cli.main import cli
 from ipor_fusion.cli.vault_cmd import _fetch_role_accounts_json
 from ipor_fusion.core.access import RoleAccount
-from ipor_fusion.errors import NotAPlasmaVaultError
+from ipor_fusion.errors import NotPlasmaVaultError
 from ipor_fusion.types import Period, RoleId
 
 VAULT = "0x2222222222222222222222222222222222222222"
@@ -129,7 +129,7 @@ class TestRoleAccounts:
         assert "--chain-id" in result.output
 
     def test_not_a_vault_is_usage_error(self, _ctx, mock_resolve, tmp_config):
-        mock_resolve.side_effect = NotAPlasmaVaultError("not a Plasma Vault")
+        mock_resolve.side_effect = NotPlasmaVaultError("not a Plasma Vault")
 
         result = CliRunner().invoke(
             cli, ["vault", "role-accounts", VAULT, "--chain-id", "1"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,6 +10,7 @@ from ipor_fusion import (
     ContractNotFoundError,
     NotPlasmaVaultError,
     RoleAccount,
+    Roles,
 )
 from ipor_fusion.cli.morpho_api import (
     MorphoApiError,
@@ -264,13 +265,14 @@ class TestVaultRoleAccounts:
         with pytest.raises(NotPlasmaVaultError, match="not a vault"):
             vault_role_accounts(vault_address=VAULT_ADDR)
 
-    def test_description_lists_roles(self):
-        # Verifies description= reached FastMCP and guards role-list drift.
+    def test_role_arg_schema_enum_matches_roles(self):
+        # Guards drift between the static RoleName Literal (advertised as a
+        # schema enum) and the Roles IntEnum.
         tools = asyncio.run(mcp.list_tools())
         tool = next(t for t in tools if t.name == "vault_role_accounts")
-        assert tool.description is not None
-        assert "ATOMIST_ROLE" in tool.description
-        assert "PUBLIC_ROLE" in tool.description
+        role_prop = tool.inputSchema["properties"]["role"]
+        enum_values = next(alt["enum"] for alt in role_prop["anyOf"] if "enum" in alt)
+        assert set(enum_values) == {r.name for r in Roles}
 
 
 class TestVaultInfoGuards:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,7 +8,7 @@ from web3 import Web3
 
 from ipor_fusion import (
     ContractNotFoundError,
-    NotAPlasmaVaultError,
+    NotPlasmaVaultError,
     RoleAccount,
 )
 from ipor_fusion.cli.morpho_api import (
@@ -253,7 +253,7 @@ class TestVaultRoleAccounts:
 
     @patch(
         "ipor_fusion.mcp.server.resolve_access_manager",
-        side_effect=NotAPlasmaVaultError("not a vault"),
+        side_effect=NotPlasmaVaultError("not a vault"),
     )
     @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
     @patch(
@@ -261,7 +261,7 @@ class TestVaultRoleAccounts:
         return_value=_config_with_provider(),
     )
     def test_guard_errors_propagate(self, _load, _ctx, _resolve):
-        with pytest.raises(NotAPlasmaVaultError, match="not a vault"):
+        with pytest.raises(NotPlasmaVaultError, match="not a vault"):
             vault_role_accounts(vault_address=VAULT_ADDR)
 
     def test_description_lists_roles(self):
@@ -292,7 +292,7 @@ class TestVaultInfoGuards:
 
     @patch(
         "ipor_fusion.mcp.server.resolve_access_manager",
-        side_effect=NotAPlasmaVaultError("does not appear to be a Plasma Vault"),
+        side_effect=NotPlasmaVaultError("does not appear to be a Plasma Vault"),
     )
     @patch("ipor_fusion.mcp.server._build_ctx", return_value=(MagicMock(), None))
     @patch(
@@ -300,7 +300,7 @@ class TestVaultInfoGuards:
         return_value=_config_with_provider(),
     )
     def test_not_a_vault_raises_typed(self, _load, _ctx, _resolve):
-        with pytest.raises(NotAPlasmaVaultError, match="does not appear"):
+        with pytest.raises(NotPlasmaVaultError, match="does not appear"):
             vault_info(vault_address=VAULT_ADDR, chain_id=1)
 
     @patch(


### PR DESCRIPTION
Move vault_role_accounts arg docs from description prose into the tool schema:

- per-arg descriptions via Annotated/Field
- role is now a schema enum (static Literal mirror of Roles, drift-guarded by test) with null = all roles
- generated description dropped; docstring keeps only summary + cost note
- Returns section dropped — outputSchema covers it

No runtime behavior change for valid inputs; lenient role strings (e.g. "atomist") are now rejected at validation instead of resolved.