### PR TITLE
feat: expose per-request RPC timeout on Web3Context.from_url

### DIFF
--- a/src/ipor_fusion/core/context.py
+++ b/src/ipor_fusion/core/context.py
@@ -15,6 +15,11 @@ class Web3Context:
 
     DEFAULT_TRANSACTION_MAX_PRIORITY_FEE = 2_000_000_000
     GAS_PRICE_MARGIN = 25
+    # web3's own HTTP default, made explicit so callers can tighten it: against
+    # a degraded RPC every request otherwise blocks for the full 30s, and a
+    # multi-call read (vault fetch, health check) fans that out into minutes of
+    # wall clock. Long-running services should pass something tighter.
+    DEFAULT_RPC_TIMEOUT_S = 30.0
 
     def __init__(
         self,
@@ -63,8 +68,11 @@ class Web3Context:
         url: str,
         private_key: str | None = None,
         gas_multiplier: float = 1.25,
+        request_timeout_s: float = DEFAULT_RPC_TIMEOUT_S,
     ) -> Web3Context:
-        web3 = Web3(Web3.HTTPProvider(url))
+        web3 = Web3(
+            Web3.HTTPProvider(url, request_kwargs={"timeout": request_timeout_s})
+        )
         chain_id = ChainId(web3.eth.chain_id)
 
         return cls(

--- a/tests/test_web3_context.py
+++ b/tests/test_web3_context.py
@@ -81,7 +81,10 @@ class TestFromUrl:
             gas_multiplier=1.5,
         )
 
-        mock_web3_cls.HTTPProvider.assert_called_once_with("http://localhost:8545")
+        mock_web3_cls.HTTPProvider.assert_called_once_with(
+            "http://localhost:8545",
+            request_kwargs={"timeout": Web3Context.DEFAULT_RPC_TIMEOUT_S},
+        )
         mock_web3_cls.assert_called_once_with(mock_provider)
         assert ctx.chain_id == ChainId(42161)
         assert ctx.signer is not None
@@ -95,6 +98,18 @@ class TestFromUrl:
         ctx = Web3Context.from_url("http://localhost:8545")
 
         assert ctx.signer is None
+
+    @patch("ipor_fusion.core.context.Web3")
+    def test_from_url_passes_custom_request_timeout(self, mock_web3_cls):
+        mock_web3_instance = MagicMock()
+        mock_web3_instance.eth.chain_id = 1
+        mock_web3_cls.return_value = mock_web3_instance
+
+        Web3Context.from_url("http://localhost:8545", request_timeout_s=10.0)
+
+        mock_web3_cls.HTTPProvider.assert_called_once_with(
+            "http://localhost:8545", request_kwargs={"timeout": 10.0}
+        )
 
 
 # ── send ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
request_timeout_s (default 30.0 — web3's own HTTP default, so behavior is unchanged) is passed to HTTPProvider as request_kwargs. Long-running consumers (MCP servers) can tighten it so a degraded RPC fails fast instead of blocking every call for the full 30s; during the 2026-07-16 incident a multi-call vault fetch against a degraded provider fanned out into minutes of wall clock per tool call.