### PR TITLE
build: install uv inside semantic-release container for build_command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,9 @@ fail_under = 95
 omit = ["src/ipor_fusion/mcp/*"]
 
 [tool.semantic_release]
-build_command = "rm -rf dist/* && uv build"
+# Runs inside the python-semantic-release Docker container, not on the runner
+# host — uv from astral-sh/setup-uv is not on PATH there, so install it first.
+build_command = "rm -rf dist/* && pip install uv && uv build"
 logging_use_named_masks = true
 commit_parser = "angular"
 major_on_zero = true


### PR DESCRIPTION
## Problem

Release run [29495422316](https://github.com/IPOR-Labs/ipor-fusion.py/actions/runs/29495422316/job/87611156775) failed in **Version release (semantic)**:

```
CalledProcessError: Command '['bash', '-c', 'rm -rf dist/* && uv build']' returned non-zero exit status 127.
```

`python-semantic-release` is a Docker action — `build_command` executes inside its container, not on the runner host. `astral-sh/setup-uv` installs uv on the host only, so `uv` does not exist in the container (exit 127 = command not found).

The pre-uv config handled this by installing the build tool in-container:
`build_command = "rm -rf dist/* && pip install poetry && poetry build"` — the uv migration (#116) dropped the `pip install` part.

## Fix

Restore the same pattern with uv:

```toml
build_command = "rm -rf dist/* && pip install uv && uv build"
```

Verified locally: `uv build` produces the sdist + wheel from a clean tree.