### PR TITLE
build: drop host .venv before in-container semantic-release build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,9 @@ omit = ["src/ipor_fusion/mcp/*"]
 [tool.semantic_release]
 # Runs inside the python-semantic-release Docker container, not on the runner
 # host — uv from astral-sh/setup-uv is not on PATH there, so install it first.
-build_command = "rm -rf dist/* && pip install uv && uv build"
+# Drop the host-created .venv too: its interpreter symlinks point at host
+# paths that don't exist in the container, and uv build refuses a broken venv.
+build_command = "rm -rf dist/* .venv && pip install uv && uv build"
 logging_use_named_masks = true
 commit_parser = "angular"
 major_on_zero = true


### PR DESCRIPTION
## Problem

Follow-up to #126. Release run [29499951846](https://github.com/IPOR-Labs/ipor-fusion.py/actions/runs/29499951846/job/87626130287) got past installing uv, then failed in `build_command`:

```
error: Failed to build /github/workspace
  Caused by: Failed to inspect Python interpreter from active virtual environment at .venv/bin/python3
  Caused by: Broken symlink at .venv/bin/python3, was the underlying Python interpreter removed?
```

The **Install** step (`uv sync`) runs on the runner host and creates `.venv` in the workspace with interpreter symlinks into the host's uv-managed Python store. The python-semantic-release container mounts that workspace; inside it uv discovers `.venv`, tries to inspect its interpreter, and hits a symlink pointing at a path that only exists on the host.

## Fix

Remove the stale `.venv` alongside `dist/*` before building, so uv falls back to the container's own Python:

```toml
build_command = "rm -rf dist/* .venv && pip install uv && uv build"
```

No later workflow step uses the workspace `.venv` (both publish steps are actions operating on `dist/`), so deleting it inside the container is safe.

Verified locally: reproduced the failure shape with a `.venv` containing a broken interpreter symlink — `uv build` from a tree without `.venv` builds the sdist + wheel cleanly.