### PR TITLE
build: refresh uv.lock in the semantic-release version commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,11 +117,16 @@ omit = ["src/ipor_fusion/mcp/*"]
 # host — uv from astral-sh/setup-uv is not on PATH there, so install it first.
 # Drop the host-created .venv too: its interpreter symlinks point at host
 # paths that don't exist in the container, and uv build refuses a broken venv.
-build_command = "rm -rf dist/* .venv && pip install uv && uv build"
+# `uv lock` re-locks the root package after the version stamp lands in
+# pyproject.toml; without it uv.lock keeps the pre-release version and every
+# PR after the release fails `uv sync --locked`. The refreshed uv.lock is
+# committed via `assets` below.
+build_command = "rm -rf dist/* .venv && pip install uv && uv lock && uv build"
 logging_use_named_masks = true
 commit_parser = "angular"
 major_on_zero = true
 version_toml = ["pyproject.toml:project.version"]
+assets = ["uv.lock"]
 
 [tool.semantic_release.branches.main]
 match = "main"


### PR DESCRIPTION
## Problem

The semantic-release flow stamps the new version into `pyproject.toml` (`version_toml`) but never regenerates `uv.lock`, which records the root package version. After every release, `main` carries a `pyproject.toml`/`uv.lock` mismatch, so the first PR based on it fails CI at `uv sync --all-extras --locked` ("The lockfile at `uv.lock` needs to be updated").

This happened after the 3.2.0 release (17594b3): PR #128 failed CI ([run](https://github.com/IPOR-Labs/ipor-fusion.py/actions/runs/29564742448/job/87834747048)) and had to absorb the lock refresh manually (78fcc1b). Without this fix, the same breakage recurs after every release.

## Fix

- Add `uv lock` to `build_command`, after the version stamp lands in `pyproject.toml` and before `uv build`. uv is already installed in the release container (aae879f).
- Add `assets = ["uv.lock"]` so the refreshed lockfile is included in the release commit.

## Why this is safe

`uv lock` without `--upgrade` keeps all existing dependency pins as long as constraints are satisfied. A version-only change of the root package produces exactly a two-line diff (verified empirically by stamping a test version and re-locking):

```
-version = "3.2.0"
+version = "9.9.9"
```

No dependency versions change. As a side effect, a release now also fails fast if the lockfile is unresolvable, instead of publishing an inconsistent state.

`uv` stays unpinned in the container on purpose — `astral-sh/setup-uv` in CI floats to latest as well, so both sides track the same version.