### PR TITLE
Feat/mcp server info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,3 +143,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/ipor_fusion"]
+
+# Ship the changelog inside the wheel so `ipor_fusion.about.read_changelog()`
+# reports what the installed version actually contains, offline. Written by
+# semantic-release before `build_command`, so each wheel carries its own entry.
+[tool.hatch.build.targets.wheel.force-include]
+"CHANGELOG.md" = "ipor_fusion/CHANGELOG.md"

--- a/src/ipor_fusion/__init__.py
+++ b/src/ipor_fusion/__init__.py
@@ -1,5 +1,4 @@
-from importlib.metadata import PackageNotFoundError, version
-
+from ipor_fusion.about import ChangelogEntry, package_version, read_changelog
 from ipor_fusion.chains import (
     CHAIN_NAME_TO_ID,
     CHAIN_NAMES,
@@ -139,13 +138,13 @@ from ipor_fusion.types import (
     TokenId,
 )
 
-try:
-    __version__ = version("ipor_fusion")
-except PackageNotFoundError:
-    __version__ = "0.0.0"
+__version__ = package_version()
 
 __all__ = [
     "__version__",
+    "ChangelogEntry",
+    "package_version",
+    "read_changelog",
     "Web3Context",
     "Call",
     "VaultSimulator",

--- a/src/ipor_fusion/__init__.py
+++ b/src/ipor_fusion/__init__.py
@@ -1,4 +1,9 @@
-from ipor_fusion.about import ChangelogEntry, package_version, read_changelog
+from ipor_fusion.about import (
+    ChangelogEntry,
+    package_version,
+    read_changelog,
+    repository_url,
+)
 from ipor_fusion.chains import (
     CHAIN_NAME_TO_ID,
     CHAIN_NAMES,
@@ -145,6 +150,7 @@ __all__ = [
     "ChangelogEntry",
     "package_version",
     "read_changelog",
+    "repository_url",
     "Web3Context",
     "Call",
     "VaultSimulator",

--- a/src/ipor_fusion/about.py
+++ b/src/ipor_fusion/about.py
@@ -1,0 +1,115 @@
+"""Self-description of the installed package: version and changelog entries.
+
+Plain dataclasses and stdlib only, so this stays importable without the
+optional `cli`/`mcp` extras.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from importlib import resources
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+_DISTRIBUTION = "ipor-fusion"
+_CHANGELOG_NAME = "CHANGELOG.md"
+
+# One heading per release, newest first, e.g. `## v3.5.0 (2026-07-30)`.
+# The date group is optional so a hand-edited heading still parses.
+_VERSION_HEADING = re.compile(r"^## v(\S+?)(?: \(([^)\n]*)\))?[ \t]*$", re.MULTILINE)
+
+_LEADING_DIGITS = re.compile(r"\d+")
+
+
+@dataclass(frozen=True, slots=True)
+class ChangelogEntry:
+    """One release section of the shipped CHANGELOG.md.
+
+    `notes` is the raw markdown between this release's heading and the next
+    one, heading excluded — never parsed further. The layout is
+    semantic-release's rather than ours and has changed under us before, while
+    the only fields worth filtering on (version, date) are already extracted.
+    An empty `notes` is normal: a release whose sole commit was its own version
+    bump has no bullets.
+    """
+
+    version: str
+    date: str | None
+    notes: str
+
+
+def package_version() -> str:
+    """Installed distribution version, or `"0.0.0"` when not installed."""
+    try:
+        return version(_DISTRIBUTION)
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+def read_changelog(since_version: str = "") -> list[ChangelogEntry]:
+    """Changelog entries, newest first. Never raises; `[]` when unreadable.
+
+    The default returns only the running version's entry, so a caller that
+    omits the argument cannot pull the full history by accident. Pass a
+    version to get everything strictly newer than it.
+
+    A version with no section yields `[]`; a release whose section is present
+    but empty yields one entry with `notes == ""`. Keep those distinguishable
+    — the second case is normal, the first means the lookup failed.
+    """
+    entries = _parse_entries(_changelog_text())
+    if not since_version:
+        current = package_version()
+        return [entry for entry in entries if entry.version == current]
+    floor = _version_key(since_version)
+    return [entry for entry in entries if _version_key(entry.version) > floor]
+
+
+def _changelog_text() -> str:
+    """CHANGELOG.md from the wheel, falling back to the source checkout."""
+    # UnicodeDecodeError is a ValueError, not an OSError — without it a single
+    # stray non-UTF-8 byte would propagate out of a function documented never
+    # to raise.
+    try:
+        packaged = resources.files("ipor_fusion") / _CHANGELOG_NAME
+        if packaged.is_file():
+            return packaged.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError, ModuleNotFoundError, TypeError):
+        pass
+    # The wheel force-include does not apply to editable installs or a plain
+    # source tree, where the file sits at the repo root.
+    try:
+        root = Path(__file__).parents[2] / _CHANGELOG_NAME
+        return root.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _parse_entries(text: str) -> list[ChangelogEntry]:
+    """Slice the file into one entry per version heading, preserving file order."""
+    headings = list(_VERSION_HEADING.finditer(text))
+    entries: list[ChangelogEntry] = []
+    for index, heading in enumerate(headings):
+        is_last = index + 1 == len(headings)
+        end = len(text) if is_last else headings[index + 1].start()
+        entries.append(
+            ChangelogEntry(
+                version=heading.group(1),
+                date=heading.group(2),
+                notes=text[heading.end() : end].strip(),
+            )
+        )
+    return entries
+
+
+def _version_key(raw: str) -> tuple[int, ...]:
+    """Segment numbers, ordered by tuple comparison; a digitless segment is 0.
+
+    Compares `3.10.0 > 3.9.0`, which string comparison gets backwards.
+    """
+    segments = raw.strip().lstrip("v").split(".")
+    return tuple(
+        int(found.group()) if (found := _LEADING_DIGITS.match(segment)) else 0
+        for segment in segments
+    )

--- a/src/ipor_fusion/about.py
+++ b/src/ipor_fusion/about.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from importlib import resources
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, metadata, version
 from pathlib import Path
 
 _DISTRIBUTION = "ipor-fusion"
 _CHANGELOG_NAME = "CHANGELOG.md"
+_REPOSITORY_LABEL = "repository"
 
 # One heading per release, newest first, e.g. `## v3.5.0 (2026-07-30)`.
 # The date group is optional so a hand-edited heading still parses.
@@ -45,6 +46,23 @@ def package_version() -> str:
         return version(_DISTRIBUTION)
     except PackageNotFoundError:
         return "0.0.0"
+
+
+def repository_url() -> str:
+    """Repository URL from package metadata, or `""` when it is unavailable.
+
+    Keeps pyproject's `[project.urls]` the single source of the URL: the build
+    backend writes each entry into the distribution as `"<label>, <url>"`.
+    """
+    try:
+        entries = metadata(_DISTRIBUTION).get_all("Project-URL") or []
+    except PackageNotFoundError:
+        return ""
+    for entry in entries:
+        label, _, url = str(entry).partition(",")
+        if label.strip().lower() == _REPOSITORY_LABEL:
+            return url.strip()
+    return ""
 
 
 def read_changelog(since_version: str = "") -> list[ChangelogEntry]:

--- a/src/ipor_fusion/cli/changelog_cmd.py
+++ b/src/ipor_fusion/cli/changelog_cmd.py
@@ -1,0 +1,63 @@
+"""`fusion changelog` — release notes of the installed package."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import click
+
+from ipor_fusion.about import ChangelogEntry, package_version, read_changelog
+
+# The CLI's only top-level leaf command: every other one is a group, because
+# every other one has more than one verb. Named after the data it prints, like
+# `vault info` and `config show` — which is also why there is no
+# `fusion server_info` mirroring the MCP tool of that name, and no
+# `fusion version` duplicating the existing `--version` flag.
+
+
+@click.command("changelog")
+@click.option(
+    "--since",
+    metavar="VERSION",
+    default="",
+    help="Show releases newer than this version, e.g. 3.1.0 "
+    "(--since 0 for the full history). Default: the installed version only.",
+)
+@click.option(
+    "--json", "json_output", is_flag=True, default=False, help="Output as JSON."
+)
+def changelog(since: str, json_output: bool) -> None:
+    """Show release notes for the installed ipor-fusion package."""
+    entries = read_changelog(since)
+    if json_output:
+        click.echo(json.dumps([asdict(entry) for entry in entries], indent=2))
+        return
+    if not entries:
+        click.echo(_nothing_to_show(since))
+        return
+    for index, entry in enumerate(entries):
+        if index:
+            click.echo()
+        _print_entry(entry)
+
+
+def _nothing_to_show(since: str) -> str:
+    """Distinguish "nothing is newer" from "the running version has no section".
+
+    The second case means the lookup failed — the changelog was unreadable, or
+    it predates the running version (an unreleased working tree).
+    """
+    if since:
+        return f"(no releases newer than {since})"
+    return f"(no changelog entry for version {package_version()})"
+
+
+def _print_entry(entry: ChangelogEntry) -> None:
+    date = f" ({entry.date})" if entry.date else ""
+    click.secho(f"v{entry.version}{date}", bold=True)
+    click.echo()
+    # Printed verbatim: it is semantic-release's markdown, and indenting it
+    # would break fenced blocks. An empty body is normal — a release whose only
+    # commit was its own version bump has no bullets.
+    click.echo(entry.notes or "(no release notes)")

--- a/src/ipor_fusion/cli/main.py
+++ b/src/ipor_fusion/cli/main.py
@@ -5,6 +5,7 @@ import sys
 
 import click
 
+from ipor_fusion.cli.changelog_cmd import changelog
 from ipor_fusion.cli.config_cmd import config
 from ipor_fusion.cli.market_cmd import market
 from ipor_fusion.cli.vault_cmd import vault
@@ -28,6 +29,7 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool, no_color: bool) -> None:
         ctx.obj["no_color"] = False
 
 
+cli.add_command(changelog)
 cli.add_command(config)
 cli.add_command(market)
 cli.add_command(vault)

--- a/src/ipor_fusion/mcp/models.py
+++ b/src/ipor_fusion/mcp/models.py
@@ -33,6 +33,7 @@ from ipor_fusion.field_docs import DOCS
 from ipor_fusion.types import AssetSource, MappingStatus, NodeStatus
 
 if TYPE_CHECKING:
+    from ipor_fusion.about import ChangelogEntry
     from ipor_fusion.core.access import RoleAccount
     from ipor_fusion.readers.oracle_mapping import OracleMapping, OracleNode
 
@@ -746,3 +747,44 @@ class VaultInfoResponse(_Base):
     reconciliation: Reconciliation
     lending_health: LendingHealth | None = None
     health_check: HealthCheck
+
+
+# ---------------------------------------------------------------------------
+# Server-info models
+# ---------------------------------------------------------------------------
+
+
+class ChangelogEntryModel(_Base):
+    """One release section of the changelog shipped inside the package."""
+
+    version: str = Field(
+        description="Release version, without the changelog heading's leading 'v'."
+    )
+    date: str | None = Field(
+        description="Release date (YYYY-MM-DD); null when the heading carries none."
+    )
+    notes: str = Field(
+        description="Raw markdown for the release, heading excluded; empty "
+        "for a release that carried no entries of its own."
+    )
+
+    @classmethod
+    def from_entry(cls, entry: ChangelogEntry) -> ChangelogEntryModel:
+        return cls(version=entry.version, date=entry.date, notes=entry.notes)
+
+
+class ServerInfoResponse(_Base):
+    """Identity of the running MCP server, plus what changed in its releases."""
+
+    name: str = Field(description="MCP server name as sent in the handshake.")
+    version: str = Field(description="Installed ipor-fusion package version.")
+    repository: str = Field(
+        description="Source repository URL; empty when the package metadata "
+        "declares none."
+    )
+    changelog: list[ChangelogEntryModel] = Field(
+        description="Newest first, and only a slice of the release history: "
+        "the running version's entry alone unless changelog_since asked for "
+        "more. Empty when nothing matches: no section for the running "
+        "version, or no release newer than changelog_since."
+    )

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -4,13 +4,13 @@ Calls the ipor_fusion SDK directly — no CLI subprocess.
 Configuration is loaded from the shared CLI config (~/.config/ipor-fusion/).
 """
 
-from importlib.metadata import version
 from typing import Annotated, Literal
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 from web3 import Web3
 
+from ipor_fusion.about import package_version, read_changelog, repository_url
 from ipor_fusion.chains import CHAIN_NAMES, ensure_supported_chain
 from ipor_fusion.cli.config_store import (
     FusionConfig,
@@ -39,11 +39,13 @@ from ipor_fusion.core.context import Web3Context
 from ipor_fusion.core.plasma_vault import PlasmaVault
 from ipor_fusion.mcp.models import (
     ActionResult,
+    ChangelogEntryModel,
     ConfigShowResponse,
     MetaMorphoVaultResponse,
     MorphoBlueMarketResponse,
     OracleMappingResponse,
     RoleAccountsResponse,
+    ServerInfoResponse,
     VaultInfoResponse,
     VaultListEntry,
 )
@@ -59,11 +61,11 @@ mcp = FastMCP(
         "Start with config_show / vault_list; vault_info is the "
         "comprehensive per-vault summary."
     ),
-    website_url="https://github.com/IPOR-Labs/ipor-fusion.py",
+    website_url=repository_url() or None,
 )
 # FastMCP exposes no version kwarg; left unset, the initialize handshake
 # reports the mcp library's version as serverInfo.version.
-mcp._mcp_server.version = version("ipor-fusion")
+mcp._mcp_server.version = package_version()
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +106,39 @@ def _build_ctx(
     if effective_block is not None:
         ctx.default_block = effective_block
     return ctx, effective_block
+
+
+# ---------------------------------------------------------------------------
+# Server tools
+# ---------------------------------------------------------------------------
+
+
+# Named after the server rather than the data — a deliberate break from the
+# kebab-to-snake naming parity the other tools keep with their CLI
+# counterparts. The initialize handshake never reaches the model, so a tool is
+# the only reliable answer to "which server is this", and version/repository
+# ride along with the changelog.
+@mcp.tool()
+def server_info(
+    changelog_since: Annotated[
+        str,
+        Field(
+            description="Return every release newer than this version, e.g. "
+            "'3.1.0'. Expects a version, not a date. Default returns only the "
+            "running version's entry."
+        ),
+    ] = "",
+) -> ServerInfoResponse:
+    """Identify this MCP server and report what changed in its releases."""
+    return ServerInfoResponse(
+        name=mcp.name,
+        version=package_version(),
+        repository=repository_url(),
+        changelog=[
+            ChangelogEntryModel.from_entry(entry)
+            for entry in read_changelog(changelog_since)
+        ],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -114,10 +114,10 @@ def _build_ctx(
 
 
 # Named after the server rather than the data — a deliberate break from the
-# kebab-to-snake naming parity the other tools keep with their CLI
-# counterparts. The initialize handshake never reaches the model, so a tool is
-# the only reliable answer to "which server is this", and version/repository
-# ride along with the changelog.
+# kebab-to-snake naming parity the other tools keep with the CLI, whose sibling
+# command is `fusion changelog`. The initialize handshake never reaches the
+# model, so a tool is the only reliable answer to "which server is this", and
+# version/repository ride along with the changelog.
 @mcp.tool()
 def server_info(
     changelog_since: Annotated[

--- a/src/ipor_fusion/mcp/server.py
+++ b/src/ipor_fusion/mcp/server.py
@@ -4,6 +4,7 @@ Calls the ipor_fusion SDK directly — no CLI subprocess.
 Configuration is loaded from the shared CLI config (~/.config/ipor-fusion/).
 """
 
+from importlib.metadata import version
 from typing import Annotated, Literal
 
 from mcp.server.fastmcp import FastMCP
@@ -51,7 +52,18 @@ from ipor_fusion.readers.morpho import MorphoReader
 from ipor_fusion.readers.oracle_mapping import build_oracle_mapping
 from ipor_fusion.types import MorphoBlueMarketId
 
-mcp = FastMCP("ipor-fusion")
+mcp = FastMCP(
+    "ipor-fusion",
+    instructions=(
+        "Inspection and configuration tools for IPOR Fusion Plasma Vaults. "
+        "Start with config_show / vault_list; vault_info is the "
+        "comprehensive per-vault summary."
+    ),
+    website_url="https://github.com/IPOR-Labs/ipor-fusion.py",
+)
+# FastMCP exposes no version kwarg; left unset, the initialize handshake
+# reports the mcp library's version as serverInfo.version.
+mcp._mcp_server.version = version("ipor-fusion")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -1,0 +1,238 @@
+"""Tests for package self-description (version + changelog parsing)."""
+
+import importlib.metadata
+import re
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ipor_fusion import ChangelogEntry, package_version, read_changelog
+from ipor_fusion.about import _changelog_text, _parse_entries, _version_key
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+SAMPLE = """# CHANGELOG
+
+<!-- version list -->
+
+## v3.5.0 (2026-07-30)
+
+### Bug Fixes
+
+- **sdk**: Surface eth_simulateV1 error objects as revert reasons
+  ([`4d44f5a`](https://github.com/IPOR-Labs/ipor-fusion.py/commit/4d44f5a))
+
+
+## v3.4.1 (2026-07-29)
+
+
+## v3.4.0 (2026-07-28)
+
+### Features
+
+- **cli**: Add a thing
+  ([`abc1234`](https://github.com/IPOR-Labs/ipor-fusion.py/commit/abc1234))
+
+
+## v0.2.0 (2024-10-29)
+
+- Initial Release
+"""
+
+# semantic-release always dates its headings; the parser tolerates one that
+# is missing so a hand-edited file still yields entries.
+UNDATED = "## v9.9.9\n\n- Hand-written\n"
+
+
+def _pyproject_version() -> str:
+    """Read project.version without tomllib (absent on Python 3.10)."""
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    found = re.search(r'^version = "([^"]+)"', text, re.MULTILINE)
+    assert found, "pyproject.toml has no top-level version"
+    return found.group(1)
+
+
+class TestPackageVersion:
+    def test_matches_distribution_metadata(self):
+        assert package_version() == importlib.metadata.version("ipor-fusion")
+
+    @patch("ipor_fusion.about.version", side_effect=PackageNotFoundError)
+    def test_falls_back_when_not_installed(self, _version):
+        assert package_version() == "0.0.0"
+
+
+class TestChangelogText:
+    """Both lookup paths. Only the fallback runs in a source checkout."""
+
+    def _packaged(self, text: str) -> MagicMock:
+        traversable = MagicMock()
+        packaged = traversable.__truediv__.return_value
+        packaged.is_file.return_value = True
+        packaged.read_text.return_value = text
+        return traversable
+
+    def test_prefers_the_copy_shipped_in_the_wheel(self):
+        with patch("ipor_fusion.about.resources.files") as files:
+            files.return_value = self._packaged(SAMPLE)
+            assert _changelog_text() == SAMPLE
+
+    def test_falls_back_to_the_checkout_when_not_packaged(self):
+        on_disk = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        with patch(
+            "ipor_fusion.about.resources.files", side_effect=ModuleNotFoundError
+        ):
+            assert _changelog_text() == on_disk
+
+    def test_survives_a_file_that_is_not_utf8(self):
+        broken = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        with (
+            patch("ipor_fusion.about.resources.files", side_effect=ModuleNotFoundError),
+            patch("pathlib.Path.read_text", side_effect=broken),
+        ):
+            assert _changelog_text() == ""
+
+    def test_returns_empty_string_when_the_file_is_nowhere(self):
+        with (
+            patch("ipor_fusion.about.resources.files", side_effect=ModuleNotFoundError),
+            patch("pathlib.Path.read_text", side_effect=OSError),
+        ):
+            assert _changelog_text() == ""
+
+
+class TestParseEntries:
+    def test_splits_on_version_headings(self):
+        entries = _parse_entries(SAMPLE)
+        assert [entry.version for entry in entries] == [
+            "3.5.0",
+            "3.4.1",
+            "3.4.0",
+            "0.2.0",
+        ]
+
+    def test_extracts_date_and_leaves_notes_raw(self):
+        entry = _parse_entries(SAMPLE)[0]
+        assert entry.date == "2026-07-30"
+        assert entry.notes.startswith("### Bug Fixes")
+        assert "[`4d44f5a`]" in entry.notes
+        assert "## v3.4.1" not in entry.notes
+
+    def test_present_section_with_no_body_yields_empty_notes(self):
+        entry = next(e for e in _parse_entries(SAMPLE) if e.version == "3.4.1")
+        assert entry.notes == ""
+
+    def test_oldest_entry(self):
+        entry = _parse_entries(SAMPLE)[-1]
+        assert entry == ChangelogEntry("0.2.0", "2024-10-29", "- Initial Release")
+
+    def test_heading_without_date(self):
+        assert _parse_entries(UNDATED) == [
+            ChangelogEntry("9.9.9", None, "- Hand-written")
+        ]
+
+    def test_no_headings(self):
+        assert _parse_entries("# CHANGELOG\n\nnothing here\n") == []
+
+
+class TestReadChangelog:
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    @patch("ipor_fusion.about.package_version", return_value="3.4.0")
+    def test_default_returns_only_the_running_version(self, _version, _text):
+        entries = read_changelog()
+        assert [entry.version for entry in entries] == ["3.4.0"]
+
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    @patch("ipor_fusion.about.package_version", return_value="3.4.1")
+    def test_running_version_with_empty_notes_still_returns_an_entry(
+        self, _version, _text
+    ):
+        entries = read_changelog()
+        assert len(entries) == 1
+        assert entries[0].notes == ""
+
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    @patch("ipor_fusion.about.package_version", return_value="9.9.9")
+    def test_running_version_absent_from_file_returns_empty_list(self, _version, _text):
+        assert read_changelog() == []
+
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    def test_since_version_returns_strictly_newer_newest_first(self, _text):
+        entries = read_changelog("3.4.0")
+        assert [entry.version for entry in entries] == ["3.5.0", "3.4.1"]
+
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    def test_since_version_newer_than_everything(self, _text):
+        assert read_changelog("4.0.0") == []
+
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    def test_since_version_accepts_a_v_prefix(self, _text):
+        assert [entry.version for entry in read_changelog("v3.4.1")] == ["3.5.0"]
+
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    def test_truncated_since_version_acts_as_a_prefix_floor(self, _text):
+        # "3" means the 3.x line and later: (3,) sorts below (3, 0, 0), so
+        # 3.0.0 itself counts as newer while 2.9.9 does not.
+        assert [entry.version for entry in read_changelog("3")] == [
+            "3.5.0",
+            "3.4.1",
+            "3.4.0",
+        ]
+
+    @patch("ipor_fusion.about._changelog_text", return_value="")
+    def test_unreadable_file_returns_empty_list(self, _text):
+        assert read_changelog() == []
+        assert read_changelog("1.0.0") == []
+
+    # Two accepted limitations, pinned so they stay visible: a since_version
+    # that is not a version at all widens the result instead of narrowing it,
+    # and a prerelease excludes the release it precedes. Only a caller reaches
+    # either — the changelog never supplies such a string — and the schema asks
+    # for a version, so both were left as they are.
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    def test_unparseable_since_version_returns_everything(self, _text):
+        assert [entry.version for entry in read_changelog("latest")] == [
+            "3.5.0",
+            "3.4.1",
+            "3.4.0",
+            "0.2.0",
+        ]
+
+    @patch("ipor_fusion.about._changelog_text", return_value=SAMPLE)
+    def test_prerelease_since_version_sorts_above_its_own_release(self, _text):
+        # "0-rc" yields 0 and the trailing "1" becomes a fourth segment, so
+        # (3, 5, 0, 1) > (3, 5, 0) and 3.5.0 itself is excluded.
+        assert read_changelog("3.5.0-rc.1") == []
+
+
+class TestVersionKey:
+    def test_orders_numerically_not_lexically(self):
+        assert _version_key("3.10.0") > _version_key("3.9.0")
+
+    def test_tolerates_junk_segments(self):
+        assert _version_key("3.x.1") == (3, 0, 1)
+
+
+class TestShippedChangelog:
+    """Guard: the running version must be documented in the changelog we ship.
+
+    Catches format drift in semantic-release's output and a changelog that
+    stopped being written at release time. One release late by construction —
+    the file only changes when a release happens, after CI has run.
+    """
+
+    def test_pyproject_version_has_a_changelog_section(self):
+        changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        assert f"## v{_pyproject_version()} (" in changelog
+
+    def test_read_changelog_finds_the_running_version(self):
+        entries = read_changelog()
+        assert [entry.version for entry in entries] == [package_version()]
+
+    def test_changelog_is_readable_from_the_installed_package(self):
+        assert _changelog_text().startswith("# CHANGELOG")
+
+    def test_wheel_force_includes_the_changelog(self):
+        # The checkout fallback in _changelog_text() masks a missing
+        # force-include, so assert the packaging config directly.
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        assert "[tool.hatch.build.targets.wheel.force-include]" in pyproject
+        assert '"CHANGELOG.md" = "ipor_fusion/CHANGELOG.md"' in pyproject

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -6,7 +6,12 @@ from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from ipor_fusion import ChangelogEntry, package_version, read_changelog
+from ipor_fusion import (
+    ChangelogEntry,
+    package_version,
+    read_changelog,
+    repository_url,
+)
 from ipor_fusion.about import _changelog_text, _parse_entries, _version_key
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -52,6 +57,20 @@ def _pyproject_version() -> str:
     return found.group(1)
 
 
+def _pyproject_repository() -> str:
+    """Read project.urls.repository without tomllib (absent on Python 3.10)."""
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    found = re.search(r'^repository = "([^"]+)"', text, re.MULTILINE)
+    assert found, "pyproject.toml has no project.urls.repository"
+    return found.group(1)
+
+
+def _project_urls(*entries: str) -> MagicMock:
+    distribution = MagicMock()
+    distribution.get_all.return_value = list(entries) or None
+    return distribution
+
+
 class TestPackageVersion:
     def test_matches_distribution_metadata(self):
         assert package_version() == importlib.metadata.version("ipor-fusion")
@@ -59,6 +78,40 @@ class TestPackageVersion:
     @patch("ipor_fusion.about.version", side_effect=PackageNotFoundError)
     def test_falls_back_when_not_installed(self, _version):
         assert package_version() == "0.0.0"
+
+
+class TestRepositoryUrl:
+    def test_matches_pyproject(self):
+        assert repository_url() == _pyproject_repository()
+
+    @patch("ipor_fusion.about.metadata")
+    def test_picks_the_repository_entry_among_the_others(self, metadata):
+        metadata.return_value = _project_urls(
+            "homepage, https://ipor.io",
+            "repository, https://github.com/IPOR-Labs/ipor-fusion.py",
+            "documentation, https://docs.ipor.io/",
+        )
+        assert repository_url() == "https://github.com/IPOR-Labs/ipor-fusion.py"
+
+    @patch("ipor_fusion.about.metadata")
+    def test_tolerates_a_capitalized_label(self, metadata):
+        # hatchling writes the label verbatim; other backends title-case it.
+        metadata.return_value = _project_urls("Repository, https://example.test/repo")
+        assert repository_url() == "https://example.test/repo"
+
+    @patch("ipor_fusion.about.metadata")
+    def test_returns_empty_when_no_entry_is_labeled_repository(self, metadata):
+        metadata.return_value = _project_urls("homepage, https://ipor.io")
+        assert repository_url() == ""
+
+    @patch("ipor_fusion.about.metadata")
+    def test_returns_empty_when_the_distribution_declares_no_urls(self, metadata):
+        metadata.return_value = _project_urls()
+        assert repository_url() == ""
+
+    @patch("ipor_fusion.about.metadata", side_effect=PackageNotFoundError)
+    def test_returns_empty_when_not_installed(self, _metadata):
+        assert repository_url() == ""
 
 
 class TestChangelogText:

--- a/tests/test_cli_changelog.py
+++ b/tests/test_cli_changelog.py
@@ -1,0 +1,129 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from ipor_fusion.about import ChangelogEntry
+from ipor_fusion.cli.main import cli
+
+ENTRY_LATEST = ChangelogEntry(
+    version="3.5.0",
+    date="2026-07-30",
+    notes="### Features\n\n* **mcp**: add a server_info tool",
+)
+ENTRY_OLDER = ChangelogEntry(
+    version="3.4.1",
+    date="2026-07-25",
+    notes="### Bug Fixes\n\n* **sdk**: export MerklClaimWrapperFuse",
+)
+ENTRY_EMPTY = ChangelogEntry(version="3.4.0", date="2026-07-20", notes="")
+ENTRY_UNDATED = ChangelogEntry(version="3.3.1", date=None, notes="* something")
+
+
+class TestChangelog:
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_default_shows_the_running_version_only(self, mock_read):
+        mock_read.return_value = [ENTRY_LATEST]
+
+        result = CliRunner().invoke(cli, ["changelog"])
+
+        assert result.exit_code == 0
+        mock_read.assert_called_once_with("")
+        assert "v3.5.0 (2026-07-30)" in result.output
+        assert "add a server_info tool" in result.output
+
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_since_is_passed_through(self, mock_read):
+        mock_read.return_value = [ENTRY_LATEST, ENTRY_OLDER]
+
+        result = CliRunner().invoke(cli, ["changelog", "--since", "3.4.0"])
+
+        assert result.exit_code == 0
+        mock_read.assert_called_once_with("3.4.0")
+        assert "v3.5.0" in result.output
+        assert "v3.4.1" in result.output
+
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_entries_are_blank_line_separated(self, mock_read):
+        mock_read.return_value = [ENTRY_LATEST, ENTRY_OLDER]
+
+        result = CliRunner().invoke(cli, ["changelog", "--since", "3.4.0"])
+
+        assert "add a server_info tool\n\nv3.4.1 (2026-07-25)" in result.output
+
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_empty_notes_render_a_placeholder(self, mock_read):
+        mock_read.return_value = [ENTRY_EMPTY]
+
+        result = CliRunner().invoke(cli, ["changelog"])
+
+        assert result.exit_code == 0
+        assert "v3.4.0 (2026-07-20)" in result.output
+        assert "(no release notes)" in result.output
+
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_missing_date_omits_the_parentheses(self, mock_read):
+        mock_read.return_value = [ENTRY_UNDATED]
+
+        result = CliRunner().invoke(cli, ["changelog"])
+
+        assert "v3.3.1\n" in result.output
+        assert "(None)" not in result.output
+
+    @patch("ipor_fusion.cli.changelog_cmd.package_version")
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_no_entry_for_the_running_version(self, mock_read, mock_version):
+        mock_read.return_value = []
+        mock_version.return_value = "9.9.9"
+
+        result = CliRunner().invoke(cli, ["changelog"])
+
+        assert result.exit_code == 0
+        assert "(no changelog entry for version 9.9.9)" in result.output
+
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_nothing_newer_than_since(self, mock_read):
+        mock_read.return_value = []
+
+        result = CliRunner().invoke(cli, ["changelog", "--since", "3.5.0"])
+
+        assert result.exit_code == 0
+        assert "(no releases newer than 3.5.0)" in result.output
+
+
+class TestChangelogJson:
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_json_carries_every_field(self, mock_read):
+        mock_read.return_value = [ENTRY_LATEST, ENTRY_UNDATED]
+
+        result = CliRunner().invoke(cli, ["changelog", "--json"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == [
+            {
+                "version": "3.5.0",
+                "date": "2026-07-30",
+                "notes": "### Features\n\n* **mcp**: add a server_info tool",
+            },
+            {"version": "3.3.1", "date": None, "notes": "* something"},
+        ]
+
+    @patch("ipor_fusion.cli.changelog_cmd.read_changelog")
+    def test_json_empty_stays_machine_readable(self, mock_read):
+        mock_read.return_value = []
+
+        result = CliRunner().invoke(cli, ["changelog", "--json"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == []
+
+
+class TestChangelogIntegration:
+    def test_reads_the_real_changelog(self):
+        """No mocks: the shipped CHANGELOG.md must be reachable from the CLI."""
+        result = CliRunner().invoke(cli, ["changelog", "--since", "0", "--json"])
+
+        assert result.exit_code == 0
+        entries = json.loads(result.output)
+        assert len(entries) > 1
+        assert all(entry["version"] for entry in entries)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,7 @@ from web3 import Web3
 
 from ipor_fusion import (
     DOCS,
+    ChangelogEntry,
     ContractNotFoundError,
     NotPlasmaVaultError,
     RoleAccount,
@@ -38,6 +39,7 @@ from ipor_fusion.mcp.server import (
     market_meta_morpho,
     market_morpho_blue,
     mcp,
+    server_info,
     vault_add,
     vault_info,
     vault_list,
@@ -90,6 +92,48 @@ class TestServerMetadata:
         opts = mcp._mcp_server.create_initialization_options()
         assert opts.instructions
         assert opts.website_url == "https://github.com/IPOR-Labs/ipor-fusion.py"
+
+
+class TestServerInfo:
+    def test_reports_the_server_name(self):
+        # Version and repository are covered by the agreement test below,
+        # which chains to the handshake tests' literals.
+        assert server_info().name == "ipor-fusion"
+
+    def test_handshake_and_tool_agree_on_version_and_repository(self):
+        # Two channels, one source: the handshake the client reads and the
+        # tool the model calls must report the same facts. They encode an
+        # unknown repository differently on purpose — the tool returns "" to
+        # keep its response shape flat, the handshake gets None because an
+        # empty websiteUrl would advertise a link to nowhere — so normalize
+        # before comparing.
+        opts = mcp._mcp_server.create_initialization_options()
+        result = server_info()
+        assert result.version == opts.server_version
+        assert result.repository == (opts.website_url or "")
+
+    def test_default_returns_only_the_running_version(self):
+        result = server_info()
+        assert [entry.version for entry in result.changelog] == [result.version]
+
+    @patch("ipor_fusion.mcp.server.read_changelog", return_value=[])
+    def test_changelog_since_is_passed_through(self, read):
+        server_info(changelog_since="3.1.0")
+        read.assert_called_once_with("3.1.0")
+
+    @patch(
+        "ipor_fusion.mcp.server.read_changelog",
+        return_value=[
+            ChangelogEntry("3.5.0", "2026-07-30", "### Bug Fixes\n\n- **sdk**: Fix"),
+            ChangelogEntry("3.4.1", None, ""),
+        ],
+    )
+    def test_maps_entries_including_a_dateless_empty_release(self, _read):
+        changelog = server_info().changelog
+        assert [(e.version, e.date, e.notes) for e in changelog] == [
+            ("3.5.0", "2026-07-30", "### Bug Fixes\n\n- **sdk**: Fix"),
+            ("3.4.1", None, ""),
+        ]
 
 
 class TestConfigShow:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,7 @@
 """Tests for the MCP server tool definitions (direct SDK import)."""
 
 import asyncio
+import importlib.metadata
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -78,6 +79,17 @@ def _config_with_vault():
         providers={"1": "https://rpc.example.com"},
         vaults=[VaultEntry(address="0xABC", label="Test", chain_id=1)],
     )
+
+
+class TestServerMetadata:
+    def test_handshake_reports_package_version(self):
+        opts = mcp._mcp_server.create_initialization_options()
+        assert opts.server_version == importlib.metadata.version("ipor-fusion")
+
+    def test_handshake_carries_instructions_and_website_url(self):
+        opts = mcp._mcp_server.create_initialization_options()
+        assert opts.instructions
+        assert opts.website_url == "https://github.com/IPOR-Labs/ipor-fusion.py"
 
 
 class TestConfigShow:


### PR DESCRIPTION
The MCP `initialize` handshake reported the `mcp` library's version as `serverInfo.version`, because `FastMCP` accepts no `version=` kwarg — and the handshake never reaches the model anyway, so clients had no way to ask which server or version they were talking to.

- `fix(mcp)`: report the installed `ipor-fusion` version in the handshake, plus `instructions` and `website_url`.
- `feat(sdk)`: new `ipor_fusion.about` — `package_version()`, `repository_url()`, `read_changelog()`, `ChangelogEntry`. `CHANGELOG.md` is force-included into the wheel so it is readable from an installed package.
- `feat(mcp)`: a `server_info` tool returning name, version, repository and changelog. `changelog_since` defaults to the running version's entry alone, so a client cannot pull the full history by accident.
- `feat(cli)`: `fusion changelog [--since VERSION] [--json]` for the same data; `--since 0` prints everything.

Four new public exports, nothing breaking, no `NOTICE:` footer needed. 431 offline tests pass, ruff and pyright clean.